### PR TITLE
8 validation index maps

### DIFF
--- a/mobile/pages/fields/field/field.js
+++ b/mobile/pages/fields/field/field.js
@@ -113,7 +113,7 @@ export const FieldVM = CanMap.extend('FieldVM', {
       get () {
         const varName = this.attr('field.name')
         const lastIndex = this.attr('lastIndexMap') && this.attr('lastIndexMap').attr(varName)
-        const isLastIndex = !!lastIndex || this.attr('fieldIndex') === lastIndex
+        const isLastIndex = this.attr('fieldIndex') === lastIndex
         const hasGroupError = this.attr('groupValidationMap') && this.attr('groupValidationMap').attr(varName)
 
         return hasGroupError && isLastIndex && this.attr('invalidPrompt')

--- a/mobile/pages/fields/fields-test.html
+++ b/mobile/pages/fields/fields-test.html
@@ -8,7 +8,7 @@
     <div id="mocha"></div>
     <div id="test-area"></div>
 
-    <script src="../../../../node_modules/steal/steal.js"
+    <script src="../../../node_modules/steal/steal.js"
       data-mocha="bdd"
       data-main="a2jviewer/mobile/pages/fields/fields-test"></script>
   </body>

--- a/mobile/pages/fields/fields-test.js
+++ b/mobile/pages/fields/fields-test.js
@@ -23,6 +23,7 @@ describe('<a2j-fields>', () => {
     })
 
     it('lastIndexMap', () => {
+      vm.connectedCallback()
       let expectedResults = {
         foo: 1,
         foobaroo: 2,
@@ -43,6 +44,7 @@ describe('<a2j-fields>', () => {
     })
 
     it('groupValidationMap', () => {
+      vm.connectedCallback()
       let expectedResults = {
         foo: false,
         foobaroo: false,

--- a/mobile/pages/fields/fields.js
+++ b/mobile/pages/fields/fields.js
@@ -26,7 +26,6 @@ export const FieldsVM = CanMap.extend('FieldsVM', {
   },
 
   buildGroupValidationMap () {
-    console.log('building gvMap')
     const fields = this.attr('fields')
     const groupValidationMap = new CanMap()
 
@@ -59,7 +58,7 @@ export const FieldsVM = CanMap.extend('FieldsVM', {
     this.attr('groupValidationMap', this.buildGroupValidationMap())
     this.attr('lastIndexMap', this.buildLastIndexMap())
 
-    // navigated pages
+    // navigated pages which resets fields list
     this.listenTo('fields', () => {
       this.attr('groupValidationMap', this.buildGroupValidationMap())
       this.attr('lastIndexMap', this.buildLastIndexMap())

--- a/mobile/pages/fields/fields.js
+++ b/mobile/pages/fields/fields.js
@@ -20,37 +20,50 @@ export const FieldsVM = CanMap.extend('FieldsVM', {
     rState: {},
     modalContent: {},
 
-    lastIndexMap: {
-      get () {
-        const fields = this.attr('fields')
-        const lastIndexMap = new CanMap()
+    lastIndexMap: {},
 
-        if (fields.length) {
-          fields.forEach((field, index) => {
-            const varName = field.attr('name')
-            lastIndexMap.attr(varName, index)
-          })
-        }
+    groupValidationMap: {}
+  },
 
-        return lastIndexMap
-      }
-    },
+  buildGroupValidationMap () {
+    console.log('building gvMap')
+    const fields = this.attr('fields')
+    const groupValidationMap = new CanMap()
 
-    groupValidationMap: {
-      get () {
-        const fields = this.attr('fields')
-        const groupValidationMap = new CanMap()
-
-        if (fields.length) {
-          fields.forEach((field) => {
-            const varName = field.attr('name')
-            groupValidationMap.attr(varName, false)
-          })
-        }
-
-        return groupValidationMap
-      }
+    if (fields.length) {
+      fields.forEach((field) => {
+        const varName = field.attr('name')
+        groupValidationMap.attr(varName, false)
+      })
     }
+
+    return groupValidationMap
+  },
+
+  buildLastIndexMap () {
+    const fields = this.attr('fields')
+    const lastIndexMap = new CanMap()
+
+    if (fields.length) {
+      fields.forEach((field, index) => {
+        const varName = field.attr('name')
+        lastIndexMap.attr(varName, index)
+      })
+    }
+
+    return lastIndexMap
+  },
+
+  connectedCallback () {
+    // first page
+    this.attr('groupValidationMap', this.buildGroupValidationMap())
+    this.attr('lastIndexMap', this.buildLastIndexMap())
+
+    // navigated pages
+    this.listenTo('fields', () => {
+      this.attr('groupValidationMap', this.buildGroupValidationMap())
+      this.attr('lastIndexMap', this.buildLastIndexMap())
+    })
   }
 })
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -3,6 +3,7 @@ import 'a2jviewer/models/tests/'
 
 import 'a2jviewer/mobile/util/tests/'
 import 'a2jviewer/mobile/pages/pages-test'
+import 'a2jviewer/mobile/pages/fields/fields-test'
 import 'a2jviewer/mobile/pages/fields/field/field-test'
 
 import 'a2jviewer/util/tests/readable-list-test'


### PR DESCRIPTION
Validation and Index maps were showing warnings in the console, this changes them from a standard getter to a combo of build functions and event listeners in connectedCallback(). covers the initial load of the fields Component and then future builds based on the `fields` list changing when users navigate to new pages. Future solution might be `value` behavior.

closes #8 