### PR TITLE
use custom opacity for disabled nav-item

### DIFF
--- a/desktop/navigation/navigation.less
+++ b/desktop/navigation/navigation.less
@@ -43,4 +43,8 @@ a2j-viewer-navigation {
   .nav li.divider {
     margin: 10px;
   }
+
+  li.nav-item.navigation-disabled{
+    opacity: 0.7;
+  }
 }

--- a/desktop/navigation/navigation.stache
+++ b/desktop/navigation/navigation.stache
@@ -12,7 +12,7 @@
       <li
         tabindex="0"
         aria-labelledby="go-back-nav-button"
-        class="nav-item {{^if(./canNavigateBack)}}disabled{{/if}}"
+        class="nav-item {{^if(./canNavigateBack)}}navigation-disabled{{/if}}"
         on:click="./navigateBack()"
         on:keydown="keydownFireClickHandler(scope.event, ./navigateBack)"
       >
@@ -24,7 +24,7 @@
       <li
         tabindex="0"
         aria-labelledby="go-next-nav-button"
-        class="nav-item  {{^if(./canNavigateForward)}}disabled{{/if}}"
+        class="nav-item  {{^if(./canNavigateForward)}}navigation-disabled{{/if}}"
         on:click="./navigateForward()"
         on:keydown="keydownFireClickHandler(scope.event, ./navigateForward)"
       >


### PR DESCRIPTION
These changes the disabled nav-item 'buttons from the standard bootstrap .disabled class which does not provide enough contrast to satisfy WCAG requirements, to use opacity 0.7 as per Adri's recommendation here: https://github.com/CCALI/CAJA/issues/1920

closes CCALI/CAJA#1920