### PR TITLE
Add Travis badges to current readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.com/CCALI/A2JViewer.svg?branch=develop)](https://travis-ci.com/CCALI/A2JViewer)
+
 # A2JViewer
 
 This repo hosts the distributable production version of the A2J Viewer.


### PR DESCRIPTION
this targets the status of the develop branch, which will be the future main branch for A2J Viewer