### PR TITLE
24 sign text macros

### DIFF
--- a/desktop/steps/steps-test.js
+++ b/desktop/steps/steps-test.js
@@ -372,14 +372,5 @@ describe('<a2j-viewer-steps>', function () {
         F(done)
       }
     )
-
-    it.skip('resolves macro values in custom sign text', function (done) {
-      const answers = interview.attr('answers')
-      answers.varSet('number', 42)
-      answers.varSet('a2j step 1', 'The answer to everything is %%[number]%%')
-
-      // F('.bg-step-zero').text(1, 'should be one arrow')
-      F(done)
-    })
   })
 })

--- a/desktop/steps/steps-test.js
+++ b/desktop/steps/steps-test.js
@@ -5,6 +5,7 @@ import _assign from 'lodash/assign'
 import stache from 'can-stache'
 import AppState from '~/models/app-state'
 import Interview from '~/models/interview'
+import Logic from '~/mobile/util/logic'
 import TraceMessage from '@caliorg/a2jdeps/models/trace-message'
 import $ from 'jquery'
 import { ViewerStepsVM } from '~/desktop/steps/'
@@ -92,13 +93,13 @@ describe('<a2j-viewer-steps>', function () {
       const step = vm.attr('interview.steps.0')
       const stepVar = vm.attr('interview.answers.a2j step 0')
 
-      assert.equal(vm.getDisplayTextForStep(step), 'Audio Test', 'show default step sign text')
+      assert.equal(vm.getTextForStep(step), 'Audio Test', 'show default step sign text')
       // update matching step var
       stepVar.attr('values.1', 'New Sign Text')
-      assert.equal(vm.getDisplayTextForStep(step), 'New Sign Text', 'Authors can set new sign displayText')
+      assert.equal(vm.getTextForStep(step), 'New Sign Text', 'Authors can set new sign displayText')
       // clear custom value
       stepVar.attr('values.1', '')
-      assert.equal(vm.getDisplayTextForStep(step), 'Audio Test', 'should restore text when step var set to empty string')
+      assert.equal(vm.getTextForStep(step), 'Audio Test', 'should restore text when step var set to empty string')
     })
 
     it('getStepIndex', () => {
@@ -107,14 +108,14 @@ describe('<a2j-viewer-steps>', function () {
       assert.equal(vm.getStepIndex(step), 2, 'it did not return the correct index for the step')
     })
 
-    it('getDisplayTextForStep', () => {
+    it('truncateText', () => {
       const step = vm.attr('interview.steps.0')
-      assert.equal(vm.getDisplayTextForStep(step), 'Audio Test', 'should not change short text')
+      assert.equal(vm.truncateText(step.text), 'Audio Test', 'should not change short text')
 
       step.attr('text', 'slightly longer text with a space as the 51st char that gets truncated')
 
       assert.equal(
-        vm.getDisplayTextForStep(step),
+        vm.truncateText(step.text),
         'slightly longer text with a space as the 51st char...',
         'should truncate to 50 chars and add an ellipsis'
       )
@@ -122,7 +123,7 @@ describe('<a2j-viewer-steps>', function () {
       step.attr('text', 'long text with a space as the 50th character in the middle of a word')
 
       assert.equal(
-        vm.getDisplayTextForStep(step),
+        vm.truncateText(step.text),
         'long text with a space as the 50th character in...',
         'should truncate to last full word before 50th char and add an ellipsis'
       )
@@ -307,20 +308,7 @@ describe('<a2j-viewer-steps>', function () {
       rState.page = interview.attr('firstPage')
       rState.interview = interview
 
-      const logicStub = new CanMap({
-        exec: $.noop,
-        infinite: {
-          errors: $.noop,
-          reset: $.noop,
-          _counter: 0,
-          inc: $.noop
-        },
-        varExists: sinon.spy(),
-        varCreate: sinon.spy(),
-        varGet: sinon.stub(),
-        varSet: sinon.spy(),
-        eval: sinon.spy()
-      })
+      const logic = new Logic({ interview })
 
       let langStub = new CanMap({
         MonthNamesShort: 'Jan, Feb',
@@ -330,14 +318,14 @@ describe('<a2j-viewer-steps>', function () {
 
       const frag = stache(
         `<a2j-viewer-steps
-        rState:bind="rState"
-        mState:bind="mState"
-        interview:bind="interview"
-        logic:bind="logicStub"
-        lang:bind="langStub"/>`
+        rState:from="rState"
+        mState:from="mState"
+        interview:from="interview"
+        logic:from="logic"
+        lang:from="langStub"/>`
       )
 
-      $('#test-area').html(frag({ rState, interview, mState, logicStub, langStub }))
+      $('#test-area').html(frag({ rState, interview, mState, logic, langStub }))
       vm = $('a2j-viewer-steps')[0].viewModel
     })
 
@@ -384,5 +372,14 @@ describe('<a2j-viewer-steps>', function () {
         F(done)
       }
     )
+
+    it.skip('resolves macro values in custom sign text', function (done) {
+      const answers = interview.attr('answers')
+      answers.varSet('number', 42)
+      answers.varSet('a2j step 1', 'The answer to everything is %%[number]%%')
+
+      // F('.bg-step-zero').text(1, 'should be one arrow')
+      F(done)
+    })
   })
 })

--- a/desktop/steps/steps.js
+++ b/desktop/steps/steps.js
@@ -412,15 +412,14 @@ export let ViewerStepsVM = CanMap.extend('ViewerStepsVM', {
   },
 
   /**
-   * @property {String} steps.ViewModel.prototype.getDisplayTextForStep getDisplayTextForStep
+   * @property {String} steps.ViewModel.prototype.truncateText truncateText
    * @parent steps.ViewModel
    *
    * final text to be displayed on step sign in viewer, truncated as needed
    */
-  getDisplayTextForStep (step) {
-    const maxChars = 50
-    const overflowText = '...'
-    const text = this.getTextForStep(step)
+  truncateText (text, maxChars, overflowText) {
+    maxChars = maxChars || 50
+    overflowText = overflowText || '...'
 
     return _truncate(text, {
       length: maxChars + overflowText.length,

--- a/desktop/steps/steps.stache
+++ b/desktop/steps/steps.stache
@@ -88,7 +88,11 @@
           </span>
         </div> <!-- sign circle -->
         <div aria-labelledby="step-{{currentStep.number}}-display-text" class="sign-content">
-          <span id="step-{{currentStep.number}}-display-text" title="{{scope.vm.getTextForStep(currentStep)}}">{{scope.vm.getDisplayTextForStep(currentStep)}}</span>
+          <span
+            id="step-{{currentStep.number}}-display-text"
+            title="{{scope.helpers.parseText(scope.vm.getTextForStep(currentStep))}}">
+              {{scope.vm.truncateText(scope.helpers.parseText(scope.vm.getTextForStep(currentStep)))}}
+          </span>
         </div> <!-- sign content -->
       </div> <!-- sign outer -->
     </div> <!-- sign wrapper -->
@@ -109,8 +113,12 @@
             <div class="sign-circle">
               <span class="circle-content">{{step.number}}</span>
             </div> <!-- sign circle -->
-            <div aria-labelledby="step-{{currentStep.number}}-display-text" class="sign-content">
-              <span id="step-{{currentStep.number}}-display-text" title="{{scope.vm.getTextForStep(step)}}">{{scope.vm.getDisplayTextForStep(step)}}</span>
+            <div aria-labelledby="step-{{step.number}}-display-text" class="sign-content">
+              <span
+                id="step-{{step.number}}-display-text"
+                title="{{scope.helpers.parseText(scope.vm.getTextForStep(step))}}">
+                  {{scope.vm.truncateText(scope.helpers.parseText(scope.vm.getTextForStep(step)))}}
+              </span>
             </div> <!-- sign content -->
           </div> <!-- sign outer -->
         </div> <!-- sign wrapper -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -942,11 +942,12 @@
       }
     },
     "@caliorg/a2jdeps": {
-      "version": "7.0.8",
-      "resolved": "https://registry.npmjs.org/@caliorg/a2jdeps/-/a2jdeps-7.0.8.tgz",
-      "integrity": "sha512-FkBttHDZIOeKRyt4X551rKXy6+fWj1qnOQ7BvridiPWScRCLgeVQfZgAOJToVE2hvgQGWMgsuXcIIzmjMLn3zw==",
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/@caliorg/a2jdeps/-/a2jdeps-7.0.9.tgz",
+      "integrity": "sha512-7iEUz/72fXlbKzX2mRxhC5+Jj+s/SGG8RoYIOTJ2ft+1K/7EMwpa+hkSGaTeCJc8hDZ7c6yu3z47XBkWpbCErQ==",
       "requires": {
         "@open-xchange/bootstrap-tokenfield": "^0.13.1",
+        "bootstrap": "^3.4.1",
         "can-component": "^4.6.3",
         "can-define": "^2.8.0",
         "can-dom-events": "^1.3.11",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     }
   },
   "dependencies": {
-    "@caliorg/a2jdeps": "^7.0.6",
+    "@caliorg/a2jdeps": "^7.0.9",
     "@open-xchange/bootstrap-tokenfield": "^0.13.1",
     "bit-tabs": "^2.0.0",
     "blueimp-file-upload": "^9.10.1",


### PR DESCRIPTION
Restores sign text macro updates using the new global parseText stache helper for 'live bound' updates. Updates @caliorg/a2jdeps dependency and tests.

close #24 