### PR TITLE
22 custom logo styles

### DIFF
--- a/desktop/desktop.less
+++ b/desktop/desktop.less
@@ -10,6 +10,7 @@ a2j-desktop-viewer {
 
     img {
       width: 120px;
+      margin-bottom: 12px; // footer height
     }
   }
 }

--- a/desktop/desktop.less
+++ b/desktop/desktop.less
@@ -10,7 +10,7 @@ a2j-desktop-viewer {
 
     img {
       width: 120px;
-      margin-bottom: 12px; // footer height
+      margin-bottom: 15px; // footer height + 3px
     }
   }
 }

--- a/mobile/pages/fields/field/views/datemdy.less
+++ b/mobile/pages/fields/field/views/datemdy.less
@@ -25,12 +25,12 @@ div.ui-datepicker {
   }
 }
 
-img {
-  margin: 2px 0px;
-  height: 22px;
-  width: auto;
-}
 
 button.ui-datepicker-trigger {
   float:right;
+    img {
+      margin: 2px 0px;
+      height: 22px;
+      width: auto;
+    }
 }


### PR DESCRIPTION
This fixes an issue where the styles for the datepicker img icon were polluting custom logo img uploads. Also adds a bit of bottom margin to make up for the footer space

closes #22 