### PR TITLE
Swipe cleanup

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,7 +11,6 @@ import PersistedState from '~/src/models/persisted-state'
 
 import 'can-3-4-compat/dom-mutation-events'
 
-import 'jquerypp/dom/cookie/'
 import '~/src/mobile/util/helpers'
 import '@caliorg/a2jdeps/calculator/jquery.plugin'
 import '@caliorg/a2jdeps/calculator/jquery.calculator'

--- a/package-lock.json
+++ b/package-lock.json
@@ -7087,11 +7087,6 @@
       "resolved": "https://registry.npmjs.org/jquery-ui/-/jquery-ui-1.12.1.tgz",
       "integrity": "sha1-vLQEXI3QU5wTS8FIjN0+dop6nlE="
     },
-    "jquerypp": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/jquerypp/-/jquerypp-2.0.2.tgz",
-      "integrity": "sha1-BvyIbhLmQ7Hwb53yIZQXj47Nk0M="
-    },
     "js-module-formats": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/js-module-formats/-/js-module-formats-0.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "http-server": "^0.12.3",
     "jquery": "^3.4.1",
     "jquery-ui": "^1.12.1",
-    "jquerypp": "^2.0.2",
     "lightbox2": "^2.10.0",
     "localforage": "^1.3.0",
     "lodash": "^4.17.15",

--- a/src/desktop/navigation/navigation.js
+++ b/src/desktop/navigation/navigation.js
@@ -7,8 +7,6 @@ import constants from '@caliorg/a2jdeps/models/constants'
 import { analytics } from '~/src/util/analytics'
 import isMobile from '~/src/util/is-mobile'
 
-import 'jquerypp/event/swipe/'
-
 /**
  * @property {can.Map} viewerNavigation.ViewModel
  * @parent <a2j-viewer-navigation>
@@ -412,27 +410,11 @@ export let ViewerNavigationVM = DefineMap.extend({
       ev.currentTarget.textContent = ''
     })
 
-    // add mobile swipe nav
-    const swipeRightHandler = function () {
-      if (vm.canNavigateBack) {
-        vm.navigateBack()
-      }
-    }
-    const swipeLeftHandler = function () {
-      if (vm.canNavigateForward) {
-        vm.navigateForward()
-      }
-    }
-    $('#viewer-app').on('swiperight', swipeRightHandler)
-    $('#viewer-app').on('swipeleft', swipeLeftHandler)
-
     // cleanup
     return () => {
       vm.rState.stopListening('selectedPageIndexSet', updateMyProgressOptions)
       myProgressSelect.removeEventListener('change', updateAppStateSelectedPageIndex)
       $('.focus-main-content a').off()
-      $('#viewer-app').off('swiperight', swipeRightHandler)
-      $('#viewer-app').off('swipeleft', swipeLeftHandler)
     }
   }
 })

--- a/src/mobile/pages/fields/field/field-test.js
+++ b/src/mobile/pages/fields/field/field-test.js
@@ -344,14 +344,16 @@ describe('<a2j-field>', () => {
         numberDollarField.attr('calculator', true)
 
         let $calcFound = $('.calc-icon')
-
-        assert.equal($calcFound.attr('class'), 'calc-icon')
+        assert.equal($calcFound.length, 1, 'should find one .calc-icon element')
       })
 
       it('should not show the calculator image when unselected', () => {
+        let numberDollarField = numberDollarVm.attr('field')
+        numberDollarField.attr('calculator', false)
+
         let $calcFound = $('.calc-icon')
 
-        assert.equal($calcFound.attr('class'), undefined)
+        assert.equal($calcFound.length, 0, 'should find zero .calc-icon element')
       })
     })
 

--- a/src/mobile/pages/fields/field/views/number.stache
+++ b/src/mobile/pages/fields/field/views/number.stache
@@ -22,7 +22,7 @@
             class="btn btn-default expand-calc pull-right"
             on:click="showCalculator(field)"
             aui-action="open">
-            <span class="icon glyphicon-calc" aria-hidden="true"></span>
+            <span class="icon calc-icon glyphicon-calc" aria-hidden="true"></span>
           </button>
         {{/if}}
     </div>

--- a/src/mobile/pages/fields/field/views/numberdollar.stache
+++ b/src/mobile/pages/fields/field/views/numberdollar.stache
@@ -24,7 +24,7 @@
             class="btn btn-default expand-calc pull-right"
             on:click="showCalculator(field)"
             aui-action="open">
-            <span class="icon glyphicon-calc" aria-hidden="true"></span>
+            <span class="icon calc-icon glyphicon-calc" aria-hidden="true"></span>
           </button>
         {{/if}}
     </div>


### PR DESCRIPTION
As part of fixing issue ccali/caja#1917 I noticed the swipe functionality was not working for the mobile viewer. @JessicaFrank and I decided to pull the non-working swipe nav out for a future fix/enhancement around mobile actions like swipe, pinch, etc and how they might improve the UX of the mobile view.

