### PR TITLE
43 remove modal backdrop during Author preview mode

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -60,6 +60,11 @@ export let ModalVM = DefineMap.extend('ViewerModalVM', {
 
   connectedCallback (el) {
     const showModalHandler = () => {
+      // modal-backdrop blocks when debug-panel is open in Author previewMode
+      // TODO: should be easier to manage when debug-panel is moved to viewer
+      if (this.previewActive) {
+        $('.modal-backdrop').remove()
+      }
       if (!this.previewActive) {
         $('body').addClass('bootstrap-styles')
       }

--- a/src/models/app-state.js
+++ b/src/models/app-state.js
@@ -101,11 +101,9 @@ export const ViewerAppState = DefineMap.extend('ViewerAppState', {
     default: () => new DefineList()
   },
 
+  // set when launched from preview.js during Author Preview
   previewActive: {
-    serialize: false,
-    get () {
-      return canReflect.getKeyValue(route.data, 'page') === 'preview'
-    }
+    serialize: false
   },
 
   saveAndExitActive: {

--- a/src/preview/preview.js
+++ b/src/preview/preview.js
@@ -47,6 +47,9 @@ export const ViewerPreviewVM = CanMap.extend('ViewerPreviewVM', {
     const mState = new MemoryState()
     const pState = new PersistedState()
 
+    // used in Viewer App during previewMode
+    rState.previewActive = true
+
     // if previewInterview.answers exist here, they are restored from Author app-state binding
     const previewAnswers = vm.attr('previewInterview.answers')
 


### PR DESCRIPTION
This removes the bootstrap modal backdrop when the Viewer apps is being used in Author as debug-panel causes the backdrop to block the UI.

closes #43