### PR TITLE
55 number error message

### DIFF
--- a/src/mobile/pages/fields/field/field-test.js
+++ b/src/mobile/pages/fields/field/field-test.js
@@ -336,6 +336,18 @@ describe('<a2j-field>', () => {
         document.getElementById('Likes Chocolate TF').click()
         assert.equal(textField.attr('_answerVm.answer.values.1'), 'Wilhelmina', 'Checking checkbox does not change text field')
       })
+
+      it('should set error state from number prevalidation', () => {
+        const e = new window.Event('input', {
+          bubbles: true,
+          cancelable: true
+        })
+        const numberDollarEl = document.getElementById('Salary')
+        numberDollarEl.value = 'safsd'
+        numberDollarEl.dispatchEvent(e)
+        const hasError = numberDollarVm.attr('groupValidationMap').attr('Salary')
+        assert.equal(hasError, true, 'pre-validation should catch number errors and update groupValidationMap')
+      })
     })
 
     describe('Calculator', () => {

--- a/src/mobile/pages/fields/field/field.js
+++ b/src/mobile/pages/fields/field/field.js
@@ -352,13 +352,16 @@ export const FieldVM = CanMap.extend('FieldVM', {
   preValidateNumber (ctx, el) {
     const $el = $(el)
     const field = this.attr('field')
+    const varName = field.attr('name')
     // accept only numbers, commas, periods, and negative sign
     const currentValue = $el.val()
     const scrubbedValue = currentValue.replace(/[^\d.,-]/g, '')
     if (currentValue !== scrubbedValue) {
       field.attr('hasError', true)
+      this.attr('groupValidationMap').attr(varName, true)
     } else {
       field.attr('hasError', false)
+      this.attr('groupValidationMap').attr(varName, false)
     }
   },
 


### PR DESCRIPTION
Fixes issue where invalid prompt wasn't showing for number and numberdollar field types. The pre-validation code was not updating the new groupValidationMap (which triggers showing the invalid prompt). 

closes #55 