### PR TITLE
change rState to appState (merge before DefineMap update)

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,18 +30,18 @@ const interviewPromise = Interview.findOne({
 const persistedStatePromise = PersistedState.findOne()
 
 // Route state
-const rState = new AppState()
-rState.connectedCallback(document.body)
+const appState = new AppState()
+appState.connectedCallback(document.body)
 
 route.register('view/{view}/page/{page}')
 route.register('view/{view}/page/{page}/{repeatVarValue}')
 route.register('view/{view}/page/{page}/{repeatVarValue}/{outerLoopVarValue}')
-route.data = rState
+route.data = appState
 
 const preventDefaultHandler = ev => ev.preventDefault()
 $('body').on('click', 'a[href="#"]', preventDefaultHandler)
 
 Promise.all([interviewPromise, persistedStatePromise])
   .then(function ([interview, pState]) {
-    startApp({ interview, pState, mState, rState })
+    startApp({ interview, pState, mState, appState })
   })

--- a/app.stache
+++ b/app.stache
@@ -6,7 +6,7 @@
   <a2j-mobile-viewer
     lang:from="lang"
     logic:from="logic"
-    rState:from="rState"
+    appState:from="appState"
     pState:from="pState"
     mState:from="mState"
     interview:from="interview"
@@ -18,10 +18,10 @@
   <a2j-desktop-viewer
     remainingSteps:to="remainingSteps"
     maxDisplayedSteps:to="maxDisplayedSteps"
-    showDebugPanel:from="rState.showDebugPanel"
+    showDebugPanel:from="appState.showDebugPanel"
     lang:from="lang"
     logic:from="logic"
-    rState:from="rState"
+    appState:from="appState"
     pState:from="pState"
     mState:from="mState"
     interview:from="interview"
@@ -34,7 +34,7 @@
   logic:from="logic"
   interview:from="interview"
   modalContent:bind="modalContent"
-  previewActive:from="rState.previewActive"
-  lastVisitedPageName:from="rState.lastVisitedPageName"
-  repeatVarValue:from="rState.repeatVarValue"
+  previewActive:from="appState.previewActive"
+  lastVisitedPageName:from="appState.lastVisitedPageName"
+  repeatVarValue:from="appState.repeatVarValue"
   class="bootstrap-styles" />

--- a/src/desktop/desktop.js
+++ b/src/desktop/desktop.js
@@ -13,7 +13,7 @@ let DesktopViewerVM = CanMap.extend('DesktopViewerVM', {
     showDebugPanel: {},
     lang: {},
     logic: {},
-    rState: {},
+    appState: {},
     pState: {},
     mState: {},
     interview: {},
@@ -61,14 +61,14 @@ let DesktopViewerVM = CanMap.extend('DesktopViewerVM', {
   },
 
   checkPageExists () {
-    const rState = this.attr('rState')
+    const appState = this.attr('appState')
     const interview = this.attr('interview')
 
-    if (!rState || !interview) return
+    if (!appState || !interview) return
 
-    const pageName = rState.page
+    const pageName = appState.page
 
-    if (rState.view === 'pages') {
+    if (appState.view === 'pages') {
       const page = interview.attr('pages').find(pageName)
       this.attr('pageNotFound', _isUndefined(page))
     }
@@ -88,7 +88,7 @@ export default Component.extend({
   },
 
   events: {
-    '{rState} page': function () {
+    '{appState} page': function () {
       this.viewModel.checkPageExists()
     }
   },

--- a/src/desktop/desktop.stache
+++ b/src/desktop/desktop.stache
@@ -7,7 +7,7 @@
   <div class="app-container" role="main">
     {{#if (pageNotFound)}}
       <div class="alert alert-danger text-center" role="alert">
-        The page {{rState.page}} does not exist!
+        The page {{appState.page}} does not exist!
       </div>
     {{else}}
       {{#not(isMobile)}}
@@ -16,7 +16,7 @@
       <a2j-viewer-navigation
         lang:from="lang"
         logic:from="logic"
-        rState:from="rState"
+        appState:from="appState"
         resumeInterview:to="resumeInterview"
         interview:from="interview"
         showDemoNotice:from="showDemoNotice"
@@ -32,7 +32,7 @@
           resumeInterview:from="resumeInterview"
           lang:from="lang"
           logic:from="logic"
-          rState:from="rState"
+          appState:from="appState"
           pState:from="pState"
           mState:from="mState"
           interview:from="interview"
@@ -47,6 +47,6 @@
       {{/if}}
     {{/if}}
 
-    <app-footer rState:from="rState" />
+    <app-footer appState:from="appState" />
   </div><!-- app-container -->
 </div><!-- app-wrapper -->

--- a/src/desktop/navigation/navigation-test.js
+++ b/src/desktop/navigation/navigation-test.js
@@ -17,7 +17,7 @@ describe('<a2j-viewer-navigation>', function () {
     let vm
     let pages
     let visited
-    let rState
+    let appState
     let interview
     let logic
 
@@ -27,11 +27,11 @@ describe('<a2j-viewer-navigation>', function () {
       promise.then(function (_interview) {
         interview = _interview
         interview.attr('answers', { 'a2j interview incomplete tf': {values: []} })
-        rState = new AppState({ interview })
+        appState = new AppState({ interview })
         pages = interview.attr('pages')
-        visited = canReflect.getKeyValue(rState, 'visitedPages')
+        visited = canReflect.getKeyValue(appState, 'visitedPages')
         logic = new Logic({ interview })
-        vm = new ViewerNavigationVM({ rState, interview, logic })
+        vm = new ViewerNavigationVM({ appState, interview, logic })
 
         done()
       })
@@ -40,7 +40,7 @@ describe('<a2j-viewer-navigation>', function () {
     it('collects feedback form data', function () {
       // simulate user navigates to interview second page.
       let secondPage = pages.attr(1)
-      vm.rState.visitedPages.unshift(secondPage)
+      vm.appState.visitedPages.unshift(secondPage)
 
       assert.deepEqual(vm.feedbackData, {
         questionid: secondPage.attr('name'),
@@ -53,119 +53,119 @@ describe('<a2j-viewer-navigation>', function () {
     })
 
     it('canSaveAndExit', function () {
-      // true only if vm.rState.lastPageBeforeExit has a non falsy value
+      // true only if vm.appState.lastPageBeforeExit has a non falsy value
       // and interview.attr('exitPage') NOT being constants.qIDNOWHERE
-      vm.rState.lastPageBeforeExit = ''
+      vm.appState.lastPageBeforeExit = ''
       interview.attr('exitPage', constants.qIDNOWHERE)
       assert.isFalse(vm.canSaveAndExit)
 
       // lastPageBeforeExit having a value means you've already hit Save&Exit button
-      vm.rState.lastPageBeforeExit = '2-Name'
+      vm.appState.lastPageBeforeExit = '2-Name'
       interview.attr('exitPage', '1-Exit')
       assert.isFalse(vm.canSaveAndExit)
 
       // exit page assigned, but Save&Exit button not hit
-      vm.rState.lastPageBeforeExit = ''
+      vm.appState.lastPageBeforeExit = ''
       interview.attr('exitPage', '1-Exit')
       assert.isTrue(vm.canSaveAndExit)
     })
 
     it('canResumeInterview - whether Resume button should be enabled', function () {
-      vm.rState.lastPageBeforeExit = ''
+      vm.appState.lastPageBeforeExit = ''
       assert.isFalse(vm.canResumeInterview)
 
-      vm.rState.lastPageBeforeExit = '1-Intro'
+      vm.appState.lastPageBeforeExit = '1-Intro'
       assert.isTrue(vm.canResumeInterview)
     })
 
     it('resumeInterview', function () {
       // navigate to first page
       visited.unshift(pages.attr(0))
-      vm.rState.selectedPageIndex = 0
+      vm.appState.selectedPageIndex = 0
 
       // navigate to second page
       visited.unshift(pages.attr(1))
-      vm.rState.selectedPageIndex = 0
+      vm.appState.selectedPageIndex = 0
 
       // navigate to exit page by normal nav (not Author best practice)
       visited.unshift(pages.attr(2))
-      vm.rState.selectedPageIndex = 0
+      vm.appState.selectedPageIndex = 0
 
       vm.resumeInterview()
       assert.equal(visited.length, 2, 'should remove the normal nav page from visitedPages on Resume')
     })
 
     it('canNavigateBack - whether back button should be enabled', function () {
-      vm.rState.connectedCallback()
+      vm.appState.connectedCallback()
       // navigate to first page
       visited.unshift(pages.attr(0))
-      vm.rState.selectedPageIndex = 0
+      vm.appState.selectedPageIndex = 0
       assert.isFalse(vm.canNavigateBack, 'false if only one page visited')
 
       // navigate to second page
       visited.unshift(pages.attr(1))
-      vm.rState.selectedPageIndex = 0
+      vm.appState.selectedPageIndex = 0
       assert.isTrue(vm.canNavigateBack, 'true when on last page')
 
       // go back to first page
-      vm.rState.selectedPageIndex = 1
+      vm.appState.selectedPageIndex = 1
       assert.isFalse(vm.canNavigateBack, 'false when on first page')
     })
 
     it('canNavigateForward - whether next button should be enabled', function () {
-      vm.rState.connectedCallback()
+      vm.appState.connectedCallback()
       // navigate to first page
       visited.unshift(pages.attr(0))
-      vm.rState.selectedPageIndex = 0
+      vm.appState.selectedPageIndex = 0
       assert.isFalse(vm.canNavigateForward, 'false if only one page visited')
 
       // navigate to second page
       visited.unshift(pages.attr(1))
-      vm.rState.selectedPageIndex = 0
+      vm.appState.selectedPageIndex = 0
       assert.isFalse(vm.canNavigateForward, 'false when on the last page')
 
       // go back to first page
-      vm.rState.selectedPageIndex = 1
+      vm.appState.selectedPageIndex = 1
       assert.isTrue(vm.canNavigateForward, 'true when on the first page')
     })
 
     it('navigateBack', () => {
-      vm.rState.connectedCallback()
+      vm.appState.connectedCallback()
       visited.unshift(pages.attr(2))
       visited.unshift(pages.attr(1))
       visited.unshift(pages.attr(0))
 
       // select most recent page
-      vm.rState.selectedPageIndex = 0
+      vm.appState.selectedPageIndex = 0
 
       vm.navigateBack()
-      assert.equal(vm.rState.selectedPageIndex, 1, 'should navigate to middle page')
+      assert.equal(vm.appState.selectedPageIndex, 1, 'should navigate to middle page')
 
       vm.navigateBack()
-      assert.equal(vm.rState.selectedPageIndex, 2, 'should navigate to oldest page')
+      assert.equal(vm.appState.selectedPageIndex, 2, 'should navigate to oldest page')
     })
 
     it('navigateForward', () => {
-      vm.rState.connectedCallback()
+      vm.appState.connectedCallback()
       visited.unshift(pages.attr(2))
       visited.unshift(pages.attr(1))
       visited.unshift(pages.attr(0))
 
       // select oldest page
-      vm.rState.selectedPageIndex = 2
+      vm.appState.selectedPageIndex = 2
 
       vm.navigateForward()
-      assert.equal(vm.rState.selectedPageIndex, 1, 'should navigate to middle page')
+      assert.equal(vm.appState.selectedPageIndex, 1, 'should navigate to middle page')
 
       vm.navigateForward()
-      assert.equal(vm.rState.selectedPageIndex, 0, 'should navigate to most recent page')
+      assert.equal(vm.appState.selectedPageIndex, 0, 'should navigate to most recent page')
     })
 
     it('disableOption', () => {
       assert.equal(vm.disableOption(0), false, 'false by default even with index 0')
 
-      // saveAndExitActive is derived from vm.rState.lastPageBeforeExit having a value
-      vm.rState.lastPageBeforeExit = '2-Name'
+      // saveAndExitActive is derived from vm.appState.lastPageBeforeExit having a value
+      vm.appState.lastPageBeforeExit = '2-Name'
       assert.equal(vm.disableOption(0), false, 'false if index is 0 and saveAndExitActive is true')
       assert.equal(vm.disableOption(1), true, 'true if index is NOT 0 and saveAndExitActive is true')
     })
@@ -368,7 +368,7 @@ describe('<a2j-viewer-navigation>', function () {
     let pages
     let visited
     let interview
-    let rState
+    let appState
     let vm // eslint-disable-line
     let lang
     let logic
@@ -378,7 +378,7 @@ describe('<a2j-viewer-navigation>', function () {
 
       promise.then(function (_interview) {
         interview = _interview
-        rState = new AppState()
+        appState = new AppState()
         lang = {
           GoNext: 'Next',
           GoBack: 'Back',
@@ -389,19 +389,19 @@ describe('<a2j-viewer-navigation>', function () {
         }
 
         pages = interview.attr('pages')
-        visited = canReflect.getKeyValue(rState, 'visitedPages')
+        visited = canReflect.getKeyValue(appState, 'visitedPages')
         logic = new Logic({ interview })
-        vm = new ViewerNavigationVM({ rState, interview, lang, logic })
+        vm = new ViewerNavigationVM({ appState, interview, lang, logic })
 
         let frag = stache(
           `<a2j-viewer-navigation interview:from="interview"
-            rState:from="rState" lang:from="lang"
+            appState:from="appState" lang:from="lang"
             showDemoNotice:bind="showDemoNotice"
             logic:from="logic" />`
         )
 
         $('#test-area').html(frag({
-          rState,
+          appState,
           interview,
           lang,
           logic,
@@ -419,10 +419,10 @@ describe('<a2j-viewer-navigation>', function () {
       // navigate to a couple of pages
       visited.unshift(pages.attr(0))
       visited.unshift(pages.attr(1))
-      // connect listeners, specifically for rState.selectedPageIndexSet
+      // connect listeners, specifically for appState.selectedPageIndexSet
       vm.connectedCallback()
-      // fire rState event
-      vm.rState.dispatch('selectedPageIndexSet')
+      // fire appState event
+      vm.appState.dispatch('selectedPageIndexSet')
       setTimeout(() => {
         assert.equal($('select option').length, 2, 'just one page visited')
         done()
@@ -451,11 +451,11 @@ describe('<a2j-viewer-navigation>', function () {
 
     it('shows/hides Resume button based on vm.canSaveAndExit', function () {
       // turn off Resume button when saveAndExitActive is false even when lastPageBeforeExit has a value
-      vm.rState.lastPageBeforeExit = '1-Intro'
+      vm.appState.lastPageBeforeExit = '1-Intro'
       assert.equal($('.can-exit').length, 0, 'Resume button should not be rendered')
 
       // turn on Resume button when Exit button has been clicked
-      vm.rState.lastPageBeforeExit = '1-Intro'
+      vm.appState.lastPageBeforeExit = '1-Intro'
       assert.equal($('.can-resume').length, 1, 'Resume button should be rendered')
     })
 

--- a/src/desktop/navigation/navigation.js
+++ b/src/desktop/navigation/navigation.js
@@ -15,7 +15,7 @@ import isMobile from '~/src/util/is-mobile'
  */
 export let ViewerNavigationVM = DefineMap.extend({
   // passed in via stache bindings
-  rState: {},
+  appState: {},
   courthouseImage: {},
   interview: {},
   lang: {},
@@ -40,7 +40,7 @@ export let ViewerNavigationVM = DefineMap.extend({
    */
   visitedPages: {
     get () {
-      return this.rState.visitedPages
+      return this.appState.visitedPages
     }
   },
 
@@ -52,7 +52,7 @@ export let ViewerNavigationVM = DefineMap.extend({
    */
   canSaveAndExit: {
     get () {
-      return !this.rState.saveAndExitActive &&
+      return !this.appState.saveAndExitActive &&
       this.interview.attr('exitPage') !== constants.qIDNOWHERE
     }
   },
@@ -65,7 +65,7 @@ export let ViewerNavigationVM = DefineMap.extend({
    */
   canResumeInterview: {
     get () {
-      return this.rState.saveAndExitActive
+      return this.appState.saveAndExitActive
     }
   },
 
@@ -78,7 +78,7 @@ export let ViewerNavigationVM = DefineMap.extend({
   canNavigateBack: {
     get () {
       let totalPages = this.visitedPages.length
-      const canNavigateBack = totalPages > 1 && this.rState.selectedPageIndex < totalPages - 1 && !this.rState.saveAndExitActive
+      const canNavigateBack = totalPages > 1 && this.appState.selectedPageIndex < totalPages - 1 && !this.appState.saveAndExitActive
       return canNavigateBack
     }
   },
@@ -92,7 +92,7 @@ export let ViewerNavigationVM = DefineMap.extend({
   canNavigateForward: {
     get () {
       let totalPages = this.visitedPages.length
-      const canNavigateForward = totalPages > 1 && this.rState.selectedPageIndex > 0 && !this.rState.saveAndExitActive
+      const canNavigateForward = totalPages > 1 && this.appState.selectedPageIndex > 0 && !this.appState.saveAndExitActive
       return canNavigateForward
     }
   },
@@ -106,7 +106,7 @@ export let ViewerNavigationVM = DefineMap.extend({
   feedbackData: {
     get () {
       const pages = this.interview.attr('pages')
-      const page = pages.find(this.rState.selectedPageName)
+      const page = pages.find(this.appState.selectedPageName)
 
       if (!page) return {}
 
@@ -134,9 +134,9 @@ export let ViewerNavigationVM = DefineMap.extend({
   saveAndExit () {
     const answers = this.interview.attr('answers')
     const exitPage = this.interview.attr('exitPage')
-    const pageName = this.rState.selectedPageName
+    const pageName = this.appState.selectedPageName
 
-    this.rState.lastPageBeforeExit = pageName
+    this.appState.lastPageBeforeExit = pageName
 
     if (window._paq) {
       analytics.trackCustomEvent('Save&Exit', 'from: ' + pageName)
@@ -146,8 +146,8 @@ export let ViewerNavigationVM = DefineMap.extend({
       answers.attr('a2j interview incomplete tf').attr('values.1', true)
     }
 
-    this.rState.page = exitPage
-    this.rState.selectedPageIndex = 0
+    this.appState.page = exitPage
+    this.appState.selectedPageIndex = 0
   },
 
   /**
@@ -158,11 +158,11 @@ export let ViewerNavigationVM = DefineMap.extend({
    */
   resumeInterview () {
     const answers = this.interview.answers
-    const resumeTargetPageName = this.rState.lastPageBeforeExit
-    this.rState.lastPageBeforeExit = null
+    const resumeTargetPageName = this.appState.lastPageBeforeExit
+    this.appState.lastPageBeforeExit = null
 
     // Special Exit page should only show in My Progress while on that page
-    this.rState.visitedPages.shift()
+    this.appState.visitedPages.shift()
 
     if (answers) {
       answers.attr('a2j interview incomplete tf').attr('values', [null])
@@ -171,7 +171,7 @@ export let ViewerNavigationVM = DefineMap.extend({
       analytics.trackCustomEvent('Resume-Interview', 'to: ' + resumeTargetPageName)
     }
     if (resumeTargetPageName) {
-      this.rState.page = resumeTargetPageName
+      this.appState.page = resumeTargetPageName
     }
   },
 
@@ -183,7 +183,7 @@ export let ViewerNavigationVM = DefineMap.extend({
    */
   navigateBack () {
     if (this.canNavigateBack) {
-      this.rState.selectedPageIndex = this.rState.selectedPageIndex + 1
+      this.appState.selectedPageIndex = this.appState.selectedPageIndex + 1
     }
   },
 
@@ -195,7 +195,7 @@ export let ViewerNavigationVM = DefineMap.extend({
    */
   navigateForward () {
     if (this.canNavigateForward) {
-      this.rState.selectedPageIndex = this.rState.selectedPageIndex - 1
+      this.appState.selectedPageIndex = this.appState.selectedPageIndex - 1
     }
   },
 
@@ -206,7 +206,7 @@ export let ViewerNavigationVM = DefineMap.extend({
    * Used to disable My Progress options when saveAndExit is active
    */
   disableOption (index) {
-    if (index !== 0 && this.rState.saveAndExitActive) {
+    if (index !== 0 && this.appState.saveAndExitActive) {
       return true
     }
     return false
@@ -382,7 +382,7 @@ export let ViewerNavigationVM = DefineMap.extend({
     // update the selectedPageIndex
     const myProgressSelect = document.getElementById('myProgressSelect')
     const updateAppStateSelectedPageIndex = (ev) => {
-      vm.rState.selectedPageIndex = myProgressSelect.selectedIndex
+      vm.appState.selectedPageIndex = myProgressSelect.selectedIndex
     }
     myProgressSelect.addEventListener('change', updateAppStateSelectedPageIndex)
 
@@ -392,13 +392,13 @@ export let ViewerNavigationVM = DefineMap.extend({
       vm.myProgressOptions.update(this.buildOptions(this.visitedPages))
     }
 
-    // rebuild options on selectedPageIndexSet dispatched on app-state level rState
+    // rebuild options on selectedPageIndexSet dispatched on app-state level appState
     // covers normal Continue button and navigation via this component, back/next or dropdown select
-    vm.rState.listenTo('selectedPageIndexSet', updateMyProgressOptions)
+    vm.appState.listenTo('selectedPageIndexSet', updateMyProgressOptions)
 
     // cleanup
     return () => {
-      vm.rState.stopListening('selectedPageIndexSet', updateMyProgressOptions)
+      vm.appState.stopListening('selectedPageIndexSet', updateMyProgressOptions)
       myProgressSelect.removeEventListener('change', updateAppStateSelectedPageIndex)
     }
   }
@@ -413,8 +413,8 @@ export let ViewerNavigationVM = DefineMap.extend({
  *
  * @codestart
  * <a2j-viewer-navigation>
- *   {(selected-page-name)}="rState.page"
- *   {(app-state)}="rState"
+ *   {(selected-page-name)}="appState.page"
+ *   {(app-state)}="appState"
  *   {(interview)}="interview">
  * </a2j-viewer-navigation>
  * @codeend

--- a/src/desktop/navigation/navigation.stache
+++ b/src/desktop/navigation/navigation.stache
@@ -40,7 +40,7 @@
             role="listbox"
             id="myProgressSelect"
             class="form-control"
-            value:from="this.rState.selectedPageIndex">
+            value:from="this.appState.selectedPageIndex">
             {{#for(option of myProgressOptions)}}
               <option value:from="scope.index" disabled:from="this.disableOption(scope.index)">
                 {{{option}}}

--- a/src/desktop/steps/steps-test.js
+++ b/src/desktop/steps/steps-test.js
@@ -23,7 +23,7 @@ describe('<a2j-viewer-steps>', function () {
     let currentPage
 
     beforeEach(() => {
-      const rState = new AppState()
+      const appState = new AppState()
 
       const logicStub = new CanMap({
         exec: $.noop,
@@ -69,13 +69,13 @@ describe('<a2j-viewer-steps>', function () {
         answers
       }
 
-      appStateTeardown = rState.connectedCallback()
-      rState.interview = interview
-      rState.logic = logicStub
-      rState.traceMessage = new TraceMessage()
-      rState.page = '01-Introduction'
+      appStateTeardown = appState.connectedCallback()
+      appState.interview = interview
+      appState.logic = logicStub
+      appState.traceMessage = new TraceMessage()
+      appState.page = '01-Introduction'
 
-      vm = new ViewerStepsVM({ rState })
+      vm = new ViewerStepsVM({ appState })
       vm.attr({ interview })
     })
 
@@ -303,10 +303,10 @@ describe('<a2j-viewer-steps>', function () {
 
       const traceMessage = new TraceMessage()
       const mState = new CanMap()
-      const rState = new AppState({ traceMessage })
-      appStateTeardown = rState.connectedCallback()
-      rState.page = interview.attr('firstPage')
-      rState.interview = interview
+      const appState = new AppState({ traceMessage })
+      appStateTeardown = appState.connectedCallback()
+      appState.page = interview.attr('firstPage')
+      appState.interview = interview
 
       const logic = new Logic({ interview })
 
@@ -318,14 +318,14 @@ describe('<a2j-viewer-steps>', function () {
 
       const frag = stache(
         `<a2j-viewer-steps
-        rState:from="rState"
+        appState:from="appState"
         mState:from="mState"
         interview:from="interview"
         logic:from="logic"
         lang:from="langStub"/>`
       )
 
-      $('#test-area').html(frag({ rState, interview, mState, logic, langStub }))
+      $('#test-area').html(frag({ appState, interview, mState, logic, langStub }))
       vm = $('a2j-viewer-steps')[0].viewModel
     })
 

--- a/src/desktop/steps/steps.js
+++ b/src/desktop/steps/steps.js
@@ -33,7 +33,7 @@ export let ViewerStepsVM = CanMap.extend('ViewerStepsVM', {
     showDebugPanel: {},
     lang: {},
     logic: {},
-    rState: {},
+    appState: {},
     pState: {},
     mState: {},
     interview: {},
@@ -47,7 +47,7 @@ export let ViewerStepsVM = CanMap.extend('ViewerStepsVM', {
      */
     userAvatar: {
       get () {
-        return this.attr('rState').userAvatar
+        return this.attr('appState').userAvatar
       }
     },
 
@@ -71,7 +71,7 @@ export let ViewerStepsVM = CanMap.extend('ViewerStepsVM', {
      */
     currentPage: {
       get () {
-        return this.attr('rState').currentPage
+        return this.attr('appState').currentPage
       }
     },
 
@@ -527,7 +527,7 @@ export let ViewerStepsVM = CanMap.extend('ViewerStepsVM', {
 
   fireLearnMoreModal () {
     const pages = this.attr('interview.pages')
-    const pageName = this.attr('rState.page')
+    const pageName = this.attr('appState.page')
 
     if (pages && pageName) {
       const page = pages.find(pageName)
@@ -560,7 +560,7 @@ export let ViewerStepsVM = CanMap.extend('ViewerStepsVM', {
         const userAvatar = answers.attr('user avatar')
         const previousUserAvatar = userAvatar.attr('values.1')
         if (previousUserAvatar) {
-          vm.attr('rState').userAvatar.update(JSON.parse(previousUserAvatar))
+          vm.attr('appState').userAvatar.update(JSON.parse(previousUserAvatar))
         }
       }
     }

--- a/src/desktop/steps/steps.stache
+++ b/src/desktop/steps/steps.stache
@@ -19,7 +19,7 @@
             resumeInterview:from="resumeInterview"
             lang:from="lang"
             logic:from="logic"
-            rState:from="rState"
+            appState:from="appState"
             pState:from="pState"
             mState:from="mState"
             interview:from="interview"

--- a/src/footer/footer.js
+++ b/src/footer/footer.js
@@ -21,7 +21,7 @@ let FooterVM = CanMap.extend({
     // Used to hide status updates in Author preview mode
     showCAJAStatus: {
       get () {
-        return !this.attr('rState.previewActive')
+        return !this.attr('appState.previewActive')
       }
     }
   }

--- a/src/mobile/mobile.js
+++ b/src/mobile/mobile.js
@@ -8,7 +8,7 @@ const MobileViewerVM = CanMap.extend('MobileViewerVM', {
     // passed in via app.stache bindings
     lang: {},
     logic: {},
-    rState: {},
+    appState: {},
     pState: {},
     mState: {},
     interview: {},

--- a/src/mobile/mobile.stache
+++ b/src/mobile/mobile.stache
@@ -23,29 +23,29 @@
   {{/if}}
 
   {{#not(tocOrCreditsShown())}}
-    {{#eq(rState.view, 'complete')}}
+    {{#eq(appState.view, 'complete')}}
       <img src="{{joinBase 'images/logo_big.png'}}" class="img-responsive" alt="author-logo-image"/>
       <div class="btn-group btn-group-justified">
         <a href="{{mState.redirect}}" aria-label="{{lang.Continue}}" class="btn btn-primary" aui-action="next">{{lang.Continue}}</a>
       </div>
     {{/eq}}
 
-    {{#eq(rState.view, 'pages')}}
+    {{#eq(appState.view, 'pages')}}
       <a2j-viewer-navigation
-        repeatVarValue:from="rState.repeatVarValue"
-        selectedPageName:from="rState.selectedPageName"
+        repeatVarValue:from="appState.repeatVarValue"
+        selectedPageName:from="appState.selectedPageName"
         lang:from="lang"
         logic:from="logic"
-        rState:from="rState"
+        appState:from="appState"
         interview:from="interview"
-        selectedPageName:bind="rState.page"
-        selectedPageIndex:bind="rState.selectedPageIndex" />
+        selectedPageName:bind="appState.page"
+        selectedPageIndex:bind="appState.selectedPageIndex" />
 
       <a2j-pages
-        currentPage:from="rState.currentPage"
+        currentPage:from="appState.currentPage"
         lang:from="lang"
         logic:from="logic"
-        rState:from="rState"
+        appState:from="appState"
         pState:from="pState"
         mState:from="mState"
         interview:from="interview"

--- a/src/mobile/pages/fields/field/field-test.js
+++ b/src/mobile/pages/fields/field/field-test.js
@@ -29,7 +29,7 @@ describe('<a2j-field>', () => {
 
       vm = new FieldVM({
         field: fieldStub,
-        rState: {
+        appState: {
           traceMessage: new TraceMessage({
             currentPageName: 'FieldTest'
           }),
@@ -47,7 +47,7 @@ describe('<a2j-field>', () => {
     it('restoreUserAvatar', () => {
       const userAvatarJSON = '{"gender":"male","isOld":true,"hasWheelchair":false,"hairColor":"grayLight","skinTone":"darker"}'
       vm.restoreUserAvatar(userAvatarJSON)
-      const userAvatar = vm.attr('rState.userAvatar')
+      const userAvatar = vm.attr('appState.userAvatar')
       assert.equal(userAvatar.hairColor, 'grayLight', 'should restore userAvatar.hairColor')
       assert.equal(userAvatar.skinTone, 'darker', 'should restore userAvatar.skinTone')
       assert.equal(userAvatar.gender, 'male', 'should restore userAvatar.skinTone')
@@ -251,7 +251,7 @@ describe('<a2j-field>', () => {
         lang: langStub,
         groupValidationMap: new CanMap(),
         lastIndexMap: new CanMap(),
-        rState: {
+        appState: {
           traceMessage: new TraceMessage({
             currentPageName: 'FieldTest'
           }),
@@ -279,7 +279,7 @@ describe('<a2j-field>', () => {
           repeatVarValue:from="repeatVarValue"
           lastIndexMap:from="lastIndexMap"
           groupValidationMap:from="groupValidationMap"
-          rState:from="rState"
+          appState:from="appState"
         />`
       )
 

--- a/src/mobile/pages/fields/field/field.js
+++ b/src/mobile/pages/fields/field/field.js
@@ -46,12 +46,12 @@ export const FieldVM = CanMap.extend('FieldVM', {
     groupValidationMap: {},
     lastIndexMap: {},
     // Type: DefineMap
-    rState: {},
+    appState: {},
 
     // used in field views/*
     repeatVarValue: {
       get () {
-        return this.attr('rState').repeatVarValue
+        return this.attr('appState').repeatVarValue
       }
     },
 
@@ -75,7 +75,7 @@ export const FieldVM = CanMap.extend('FieldVM', {
      */
     userAvatar: {
       get () {
-        return this.attr('rState').userAvatar
+        return this.attr('appState').userAvatar
       }
     },
 
@@ -178,7 +178,7 @@ export const FieldVM = CanMap.extend('FieldVM', {
     savedGenderValue: {
       get: function () {
         let name = this.attr('field.name').toLowerCase()
-        let answerIndex = this.attr('rState.answerIndex')
+        let answerIndex = this.attr('appState.answerIndex')
         let answers = this.attr('logic.interview.answers')
         if (name && answers) {
           return answers.attr(name).attr('values.' + answerIndex)
@@ -339,7 +339,7 @@ export const FieldVM = CanMap.extend('FieldVM', {
         { format: 'val', msg: value }
       ]
     }
-    this.attr('rState').traceMessage.addMessage(message)
+    this.attr('appState').traceMessage.addMessage(message)
   },
 
   /**
@@ -426,7 +426,7 @@ export const FieldVM = CanMap.extend('FieldVM', {
    */
   expandTextlong (field) {
     const answerName = field.attr('name')
-    const previewActive = this.attr('rState.previewActive')
+    const previewActive = this.attr('appState.previewActive')
     // warning modal only in Author
     if (!answerName && previewActive) {
       this.attr('modalContent', { title: 'Author Warning', text: 'Text(long) fields require an assigned variable to expand' })

--- a/src/mobile/pages/fields/fields.js
+++ b/src/mobile/pages/fields/fields.js
@@ -17,7 +17,7 @@ export const FieldsVM = CanMap.extend('FieldsVM', {
     lang: {},
     logic: {},
     fields: {},
-    rState: {},
+    appState: {},
     modalContent: {},
 
     lastIndexMap: {},

--- a/src/mobile/pages/fields/fields.stache
+++ b/src/mobile/pages/fields/fields.stache
@@ -6,7 +6,7 @@
     groupValidationMap:from="groupValidationMap"
     lang:from="lang"
     logic:from="logic"
-    repeatVarValue:from="rState.repeatVarValue"
-    rState:from="rState"
+    repeatVarValue:from="appState.repeatVarValue"
+    appState:from="appState"
     modalContent:bind="modalContent" />
 {{/for}}

--- a/src/mobile/pages/pages-test.js
+++ b/src/mobile/pages/pages-test.js
@@ -58,7 +58,7 @@ describe('<a2j-pages>', () => {
         step: { number: '0', text: 'Step 0' } }
       ),
       logic: logic,
-      rState: new AppState({ interview, logic, traceMessage }),
+      appState: new AppState({ interview, logic, traceMessage }),
       mState: { },
       interview,
       groupValidationMap: new CanMap()
@@ -73,7 +73,7 @@ describe('<a2j-pages>', () => {
     beforeEach(() => {
       vm = new PagesVM(defaults)
       vm.connectedCallback()
-      appStateTeardown = vm.attr('rState').connectedCallback()
+      appStateTeardown = vm.attr('appState').connectedCallback()
     })
 
     afterEach(() => {
@@ -145,14 +145,14 @@ describe('<a2j-pages>', () => {
       })
 
       it('navigates to prior question with BACK button', () => {
-        const rState = vm.attr('rState')
-        const visitedPages = rState.visitedPages
+        const appState = vm.attr('appState')
+        const visitedPages = appState.visitedPages
         const button = new CanMap({ next: constants.qIDBACK })
         visitedPages[0] = defaults.currentPage
         visitedPages[1] = new CanMap({ name: 'priorPage' })
 
         vm.navigate(button)
-        assert.equal(rState.page, 'priorPage', 'should navigate to prior page')
+        assert.equal(appState.page, 'priorPage', 'should navigate to prior page')
       })
 
       it('saves answer when button has a value with special buttons as next target', () => {
@@ -377,7 +377,7 @@ describe('<a2j-pages>', () => {
         vm.attr('interview.answers.statete', answerVar)
 
         vm.attr('currentPage.fields').push(field)
-        vm.attr('rState').page = 'Next' // page find() always returns nextPageStub
+        vm.attr('appState').page = 'Next' // page find() always returns nextPageStub
 
         vm.setFieldAnswers(vm.attr('currentPage.fields'))
 
@@ -422,7 +422,7 @@ describe('<a2j-pages>', () => {
         vm.attr('interview.answers.statete', answerVar)
 
         nextPageStub.fields.push(field)
-        vm.attr('rState').page = 'Next' // page find() always returns nextPageStub
+        vm.attr('appState').page = 'Next' // page find() always returns nextPageStub
 
         vm.setFieldAnswers(vm.attr('currentPage.fields'))
 
@@ -446,7 +446,7 @@ describe('<a2j-pages>', () => {
         vm.attr('interview.answers.somenum', answerVar)
 
         vm.attr('currentPage.fields').push(field)
-        vm.attr('rState').page = 'Next' // page find() always returns nextPageStub
+        vm.attr('appState').page = 'Next' // page find() always returns nextPageStub
 
         vm.setFieldAnswers(vm.attr('currentPage.fields'))
 
@@ -470,7 +470,7 @@ describe('<a2j-pages>', () => {
         vm.attr('interview.answers.salary', answerVar)
 
         vm.attr('currentPage.fields').push(field)
-        vm.attr('rState').page = 'Next' // page find() always returns nextPageStub
+        vm.attr('appState').page = 'Next' // page find() always returns nextPageStub
 
         vm.setFieldAnswers(vm.attr('currentPage.fields'))
 
@@ -480,7 +480,7 @@ describe('<a2j-pages>', () => {
   })
 
   describe('Component', () => {
-    let rStateTeardown
+    let appStateTeardown
     beforeEach(() => {
       let frag = stache(
         '<a2j-pages></a2j-pages>'
@@ -489,7 +489,7 @@ describe('<a2j-pages>', () => {
       vm = $('a2j-pages')[0].viewModel
       vm.attr(defaults)
       vm.connectedCallback()
-      rStateTeardown = vm.attr('rState').connectedCallback()
+      appStateTeardown = vm.attr('appState').connectedCallback()
     })
 
     it('fires setFieldAnswers to update repeat loops', () => {
@@ -499,13 +499,13 @@ describe('<a2j-pages>', () => {
       vm.navigate(button)
       assert.equal(setFieldAnswersSpy.calledOnce, true, 'should call setFieldAnswers once if no repeat loop')
 
-      vm.attr('rState.repeatVarValue', 1)
+      vm.attr('appState.repeatVarValue', 1)
       vm.navigate(button)
       assert.equal(setFieldAnswersSpy.callCount, 2, 'should call setFieldAnswers twice with repeat loop')
     })
 
     afterEach(() => {
-      rStateTeardown()
+      appStateTeardown()
       $('#test-area').empty()
     })
   })

--- a/src/mobile/pages/pages-vm.js
+++ b/src/mobile/pages/pages-vm.js
@@ -26,7 +26,7 @@ export default CanMap.extend('PagesVM', {
     resumeInterview: {},
     lang: {},
     logic: {},
-    rState: {},
+    appState: {},
     pState: {},
     mState: {},
     interview: {},
@@ -37,13 +37,13 @@ export default CanMap.extend('PagesVM', {
     previewActive: {
       get (lastSet) {
         if (lastSet) { return lastSet } // for testing override
-        return this.attr('rState').previewActive
+        return this.attr('appState').previewActive
       }
     },
 
     repeatVarValue: {
       get () {
-        return this.attr('rState').repeatVarValue
+        return this.attr('appState').repeatVarValue
       }
     },
 
@@ -177,7 +177,7 @@ export default CanMap.extend('PagesVM', {
   },
 
   returnHome () {
-    this.attr('rState').attr({}, true)
+    this.attr('appState').attr({}, true)
   },
 
   validateAllFields () {
@@ -197,7 +197,7 @@ export default CanMap.extend('PagesVM', {
   },
 
   traceButtonClicked (buttonLabel) {
-    this.attr('rState.traceMessage').addMessage({
+    this.attr('appState.traceMessage').addMessage({
       key: 'button',
       fragments: [
         { format: '', msg: 'You pressed' },
@@ -207,7 +207,7 @@ export default CanMap.extend('PagesVM', {
   },
 
   traceMessageAfterQuestion () {
-    this.attr('rState.traceMessage').addMessage({
+    this.attr('appState.traceMessage').addMessage({
       key: 'codeAfter',
       fragments: [{ format: 'info', msg: 'Logic After Question' }]
     })
@@ -223,11 +223,11 @@ export default CanMap.extend('PagesVM', {
       ev && ev.preventDefault()
       return false
     } else { // no errors/normal navigation
-      const rState = vm.attr('rState')
+      const appState = vm.attr('appState')
       const page = vm.attr('currentPage')
       const logic = vm.attr('logic')
       const previewActive = vm.attr('previewActive')
-      const onExitPage = rState.saveAndExitActive && (rState.currentPage.name === vm.attr('interview').exitPage)
+      const onExitPage = appState.saveAndExitActive && (appState.currentPage.name === vm.attr('interview').exitPage)
 
       button.next = vm.handleCrossedUseOfResumeOrBack(button, onExitPage)
 
@@ -242,7 +242,7 @@ export default CanMap.extend('PagesVM', {
 
       vm.setRepeatVariable(button) // set counting variables if exist
 
-      vm.handleBackButton(button, rState, logic) // prior question
+      vm.handleBackButton(button, appState, logic) // prior question
 
       if (previewActive && this.isSpecialButton(button)) {
         vm.handlePreviewResponses(button, ev) // a2j-viewer preview messages
@@ -254,8 +254,8 @@ export default CanMap.extend('PagesVM', {
         return // final POST buttons skip rest of navigate
       }
 
-      rState.page = vm.getNextPage(button, logic) // check for GOTO logic redirect, nav to next page
-      return rState.page // return destination page for testing
+      appState.page = vm.getNextPage(button, logic) // check for GOTO logic redirect, nav to next page
+      return appState.page // return destination page for testing
     }
   },
 
@@ -351,7 +351,7 @@ export default CanMap.extend('PagesVM', {
 
     if (repeatVar && repeatVarSet) {
       const logic = this.attr('logic')
-      const traceMessage = this.attr('rState.traceMessage')
+      const traceMessage = this.attr('appState.traceMessage')
       const traceMsg = {}
 
       switch (repeatVarSet) {
@@ -449,10 +449,10 @@ export default CanMap.extend('PagesVM', {
     })
   },
 
-  handleBackButton (button, rState, logic) {
+  handleBackButton (button, appState, logic) {
     if (button.next !== constants.qIDBACK) { return }
     // last visited page always at index 1
-    const priorQuestionName = rState.visitedPages[1].name
+    const priorQuestionName = appState.visitedPages[1].name
     // override with new gotoPage
     logic.attr('gotoPage', priorQuestionName)
     button.attr('next', priorQuestionName)
@@ -529,9 +529,9 @@ export default CanMap.extend('PagesVM', {
   setFieldAnswers (fields) {
     const logic = this.attr('logic')
     if (logic && fields.length) {
-      const rState = this.attr('rState')
+      const appState = this.attr('appState')
       const mState = this.attr('mState')
-      const answerIndex = rState.answerIndex
+      const answerIndex = appState.answerIndex
 
       fields.forEach(field => {
         const answer = this.__ensureFieldAnswer(field)
@@ -588,7 +588,7 @@ export default CanMap.extend('PagesVM', {
   logVarMessage (answerName, answerValue, isRepeating, answerIndex) {
     const answerIndexDisplay = isRepeating ? `#${answerIndex}` : ''
 
-    this.attr('rState.traceMessage').addMessage({
+    this.attr('appState.traceMessage').addMessage({
       key: answerName,
       fragments: [
         { format: 'var', msg: answerName + answerIndexDisplay },

--- a/src/mobile/pages/pages.js
+++ b/src/mobile/pages/pages.js
@@ -49,7 +49,7 @@ export default Component.extend({
 
       const vm = this.viewModel
       const pages = vm.attr('interview.pages')
-      const pageName = vm.attr('rState.page')
+      const pageName = vm.attr('appState.page')
 
       if (pages && pageName) {
         const page = pages.find(pageName)
@@ -131,16 +131,16 @@ export default Component.extend({
     },
 
     // any navigation from myProgress, check for and re-render page fields for loop values
-    '{rState} selectedPageIndexSet': function () {
+    '{appState} selectedPageIndexSet': function () {
       const vm = this.viewModel
       // repeatVarValue means we're in a loop
-      if (vm.attr('rState.repeatVarValue')) {
+      if (vm.attr('appState.repeatVarValue')) {
         const fields = vm.attr('currentPage.fields')
         vm.setFieldAnswers(fields)
       }
     },
 
-    '{rState} setCurrentPage': function () {
+    '{appState} setCurrentPage': function () {
       this.viewModel.setCurrentPage()
     }
   }

--- a/src/mobile/pages/pages.stache
+++ b/src/mobile/pages/pages.stache
@@ -2,7 +2,7 @@
 <can-import from="~/src/mobile/pages/pages.less!" />
 <can-import from='~/src/audio-player/' />
 
-{{#eq(rState.page, '__error')}}
+{{#eq(appState.page, '__error')}}
   <div class="jumbotron">
     <h1>Oops!</h1>
     <p>You've reached this page in error.</p>
@@ -31,7 +31,7 @@
             logic:from="logic"
             fields:from="currentPage.fields"
             groupValidationMap:to="groupValidationMap"
-            rState:from="rState"
+            appState:from="appState"
             modalContent:bind="modalContent" />
         {{/if}}
       </div>

--- a/src/modal/modal-test.js
+++ b/src/modal/modal-test.js
@@ -22,7 +22,7 @@ describe('<a2j-modal> ', function () {
         }
       }
 
-      const rState = new AppState({ page: 'foo' })
+      const appState = new AppState({ page: 'foo' })
       const mState = new CanMap({ fileDataURL: '../../tests/images/' })
       const logic = new CanMap({ eval (html) { return html } })
       const ModalContent = CanMap.extend({
@@ -48,12 +48,12 @@ describe('<a2j-modal> ', function () {
           logic:from="logic"
           interview:from="interview"
           modalContent:bind="modalContent"
-          previewActive:from="rState.previewActive"
-          lastVisitedPageName:from="rState.lastVisitedPageName"
-          repeatVarValue:from="rState.repeatVarValue"
+          previewActive:from="appState.previewActive"
+          lastVisitedPageName:from="appState.lastVisitedPageName"
+          repeatVarValue:from="appState.repeatVarValue"
           />`
       )
-      vm = new ModalVM({ interview, rState, logic, mState, modalContent, pauseActivePlayers: pauseActivePlayersSpy })
+      vm = new ModalVM({ interview, appState, logic, mState, modalContent, pauseActivePlayers: pauseActivePlayersSpy })
       // stub app-state parseText helper
       stache.registerHelper('parseText', (text) => text)
 

--- a/src/models/tests/interview-test.html
+++ b/src/models/tests/interview-test.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Interview Model Tests</title>
+  </head>
+
+  <body>
+    <div id="mocha"></div>
+    <div id="test-area"></div>
+
+    <script src="../../../node_modules/steal/steal.js"
+      data-mocha="bdd"
+      data-main="~/src/models/tests/interview-test"></script>
+  </body>
+</html>

--- a/src/preview/preview.js
+++ b/src/preview/preview.js
@@ -26,11 +26,11 @@ export const ViewerPreviewVM = CanMap.extend('ViewerPreviewVM', {
     previewInterview: {},
     interviewPageName: {
       get: function () {
-        return this.attr('rState.page')
+        return this.attr('appState.page')
       }
     },
     // set by attr call in connectedCallback
-    rState: {},
+    appState: {},
     pState: {},
     mState: {},
     interview: {},
@@ -42,13 +42,13 @@ export const ViewerPreviewVM = CanMap.extend('ViewerPreviewVM', {
 
   connectedCallback (el) {
     const vm = this
-    const rState = new AppState()
-    const tearDownAppState = rState.connectedCallback(el)
+    const appState = new AppState()
+    const tearDownAppState = appState.connectedCallback(el)
     const mState = new MemoryState()
     const pState = new PersistedState()
 
     // used in Viewer App during previewMode
-    rState.previewActive = true
+    appState.previewActive = true
 
     // if previewInterview.answers exist here, they are restored from Author app-state binding
     const previewAnswers = vm.attr('previewInterview.answers')
@@ -73,34 +73,34 @@ export const ViewerPreviewVM = CanMap.extend('ViewerPreviewVM', {
     answers.attr('lang', lang)
     interview.attr('answers', answers)
 
-    rState.interview = interview
+    appState.interview = interview
 
     // needs to be created after answers are set
     const logic = new Logic({ interview })
-    rState.logic = logic
-    rState.traceMessage = this.traceMessage
+    appState.logic = logic
+    appState.traceMessage = this.traceMessage
 
     // listen for _tLogic trace message events
-    const tLogic = rState.logic._tLogic
+    const tLogic = appState.logic._tLogic
     const tLogicMessageHandler = (ev) => {
-      rState.traceMessage.addMessage(ev.message)
+      appState.traceMessage.addMessage(ev.message)
     }
     tLogic.listenTo('traceMessage', tLogicMessageHandler)
 
     // if previewPageName is set, we need to make sure the viewer
     // loads that specific page (covers the case when user clicks
     // `preview` from the edit page popup).
-    rState.view = 'pages'
+    appState.view = 'pages'
     if (vm.attr('previewPageName')) {
-      rState.set('page', vm.attr('previewPageName'))
+      appState.set('page', vm.attr('previewPageName'))
     } else {
-      rState.set('page', interview.attr('firstPage'))
+      appState.set('page', interview.attr('firstPage'))
     }
 
     const modalContent = compute()
 
     vm.attr({
-      rState,
+      appState,
       pState,
       mState,
       interview,

--- a/start-app.js
+++ b/start-app.js
@@ -13,7 +13,7 @@ import route from 'can-route'
 
 import '~/src/util/object-assign-polyfill'
 
-export default function ({ interview, pState, mState, rState }) {
+export default function ({ interview, pState, mState, appState }) {
   route.start()
 
   pState = pState || new PersistedState()
@@ -39,20 +39,20 @@ export default function ({ interview, pState, mState, rState }) {
 
   pState.backup()
 
-  rState.bind('change', function (ev, attr, how, val) {
+  appState.bind('change', function (ev, attr, how, val) {
     if (attr === 'page' && val) {
       pState.attr('currentPage', val)
     }
   })
 
-  rState.interview = interview
+  appState.interview = interview
   setMobileDesktopClass(isMobile, $('body'))
 
-  rState.logic = logic
+  appState.logic = logic
 
   // set initial page route
-  rState.view = 'pages'
-  rState.page = interview.attr('firstPage')
+  appState.view = 'pages'
+  appState.page = interview.attr('firstPage')
 
   const modalContent = compute()
 
@@ -61,6 +61,6 @@ export default function ({ interview, pState, mState, rState }) {
   analytics.initialize(authorId)
 
   $('#viewer-app').append(template({
-    rState, pState, mState, interview, logic, lang, isMobile, modalContent
+    appState, pState, mState, interview, logic, lang, isMobile, modalContent
   }))
 }


### PR DESCRIPTION
this just renames the top level state to appState instead of rState (routeState). It better reflects it's use throughout the Viewer app as a top level state object, and sets the Viewer up for future versions of CanJs where the routeState is it's own observable object.