### PR TITLE
76 upgrade canmap definemap

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,8 +10,12 @@ import MemoryState from '~/src/models/memory-state'
 import PersistedState from '~/src/models/persisted-state'
 
 import 'can-3-4-compat/dom-mutation-events'
-
 import '~/src/mobile/util/helpers'
+
+// !steal-remove-start
+import debug from 'can-debug'
+debug()
+// !steal-remove-end
 
 // State attrs not needing persistance, such as showing/hiding the table of contents.
 // Load configuration from desktop into mobile

--- a/app.js
+++ b/app.js
@@ -30,18 +30,18 @@ const interviewPromise = Interview.findOne({
 const persistedStatePromise = PersistedState.findOne()
 
 // Route state
-const rState = new AppState()
-rState.connectedCallback(document.body)
+const appState = new AppState()
+appState.connectedCallback(document.body)
 
 route.register('view/{view}/page/{page}')
 route.register('view/{view}/page/{page}/{repeatVarValue}')
 route.register('view/{view}/page/{page}/{repeatVarValue}/{outerLoopVarValue}')
-route.data = rState
+route.data = appState
 
 const preventDefaultHandler = ev => ev.preventDefault()
 $('body').on('click', 'a[href="#"]', preventDefaultHandler)
 
 Promise.all([interviewPromise, persistedStatePromise])
   .then(function ([interview, pState]) {
-    startApp({ interview, pState, mState, rState })
+    startApp({ interview, pState, mState, appState })
   })

--- a/app.stache
+++ b/app.stache
@@ -11,7 +11,6 @@
     mState:from="mState"
     interview:from="interview"
     traceMessage:to="traceMessage"
-    modalContent:bind="modalContent"
     class="bootstrap-styles" />
 {{else}}
   {{ let remainingSteps = null, maxDisplayedSteps = null }}
@@ -25,16 +24,12 @@
     pState:from="pState"
     mState:from="mState"
     interview:from="interview"
-    modalContent:bind="modalContent"
     class="bootstrap-styles steps-left-{{remainingSteps}} steps-{{maxDisplayedSteps}}" />
 {{/if}}
 
 <a2j-modal
+  appState:from="appState"
   mState:from="mState"
   logic:from="logic"
   interview:from="interview"
-  modalContent:bind="modalContent"
-  previewActive:from="appState.previewActive"
-  lastVisitedPageName:from="appState.lastVisitedPageName"
-  repeatVarValue:from="appState.repeatVarValue"
   class="bootstrap-styles" />

--- a/app.stache
+++ b/app.stache
@@ -6,7 +6,7 @@
   <a2j-mobile-viewer
     lang:from="lang"
     logic:from="logic"
-    rState:from="rState"
+    appState:from="appState"
     pState:from="pState"
     mState:from="mState"
     interview:from="interview"
@@ -18,10 +18,10 @@
   <a2j-desktop-viewer
     remainingSteps:to="remainingSteps"
     maxDisplayedSteps:to="maxDisplayedSteps"
-    showDebugPanel:from="rState.showDebugPanel"
+    showDebugPanel:from="appState.showDebugPanel"
     lang:from="lang"
     logic:from="logic"
-    rState:from="rState"
+    appState:from="appState"
     pState:from="pState"
     mState:from="mState"
     interview:from="interview"
@@ -34,7 +34,7 @@
   logic:from="logic"
   interview:from="interview"
   modalContent:bind="modalContent"
-  previewActive:from="rState.previewActive"
-  lastVisitedPageName:from="rState.lastVisitedPageName"
-  repeatVarValue:from="rState.repeatVarValue"
+  previewActive:from="appState.previewActive"
+  lastVisitedPageName:from="appState.lastVisitedPageName"
+  repeatVarValue:from="appState.repeatVarValue"
   class="bootstrap-styles" />

--- a/src/desktop/desktop.js
+++ b/src/desktop/desktop.js
@@ -15,7 +15,11 @@ let DesktopViewerVM = DefineMap.extend('DesktopViewerVM', {
   pState: {},
   mState: {},
   interview: {},
-  modalContent: {},
+  modalContent: {
+    get () {
+      return this.appState.modalContent
+    }
+  },
   // passed up from steps.js
   traceMessage: {},
   // singleton compute

--- a/src/desktop/desktop.js
+++ b/src/desktop/desktop.js
@@ -2,6 +2,7 @@ import CanMap from 'can-map'
 import Component from 'can-component'
 import template from './desktop.stache'
 import _isUndefined from 'lodash/isUndefined'
+import isMobile from '~/src/util/is-mobile'
 
 import 'can-map-define'
 
@@ -18,6 +19,11 @@ let DesktopViewerVM = CanMap.extend('DesktopViewerVM', {
     mState: {},
     interview: {},
     modalContent: {},
+    isMobile: {
+      get () {
+        return isMobile()
+      }
+    },
 
     pageNotFound: {
       value: false

--- a/src/desktop/desktop.js
+++ b/src/desktop/desktop.js
@@ -1,48 +1,47 @@
-import CanMap from 'can-map'
+import DefineMap from 'can-define/map/map'
 import Component from 'can-component'
 import template from './desktop.stache'
 import _isUndefined from 'lodash/isUndefined'
 import isMobile from '~/src/util/is-mobile'
 
-import 'can-map-define'
+let DesktopViewerVM = DefineMap.extend('DesktopViewerVM', {
+  // passed in via viewer app.stache bindings
+  remainingSteps: {},
+  maxDisplayedSteps: {},
+  showDebugPanel: {},
+  lang: {},
+  logic: {},
+  appState: {},
+  pState: {},
+  mState: {},
+  interview: {},
+  modalContent: {},
+  // passed up from steps.js
+  traceMessage: {},
+  // singleton compute
+  isMobile: {
+    get () {
+      return isMobile()
+    }
+  },
 
-let DesktopViewerVM = CanMap.extend('DesktopViewerVM', {
-  define: {
-    // passed in via viewer app.stache bindings
-    remainingSteps: {},
-    maxDisplayedSteps: {},
-    showDebugPanel: {},
-    lang: {},
-    logic: {},
-    appState: {},
-    pState: {},
-    mState: {},
-    interview: {},
-    modalContent: {},
-    isMobile: {
-      get () {
-        return isMobile()
-      }
-    },
+  pageNotFound: {
+    default: false
+  },
 
-    pageNotFound: {
-      value: false
-    },
+  showDemoNotice: {
+    default: false
+  },
 
-    showDemoNotice: {
-      value: false
-    },
+  authorBrandLogo: {
+    get () {
+      return this.interview.logoImage
+    }
+  },
 
-    authorBrandLogo: {
-      get () {
-        return this.attr('interview.logoImage')
-      }
-    },
-
-    authorCourthouseImage: {
-      get () {
-        return this.attr('interview.endImage')
-      }
+  authorCourthouseImage: {
+    get () {
+      return this.interview.endImage
     }
   },
 
@@ -57,7 +56,7 @@ let DesktopViewerVM = CanMap.extend('DesktopViewerVM', {
     skipLink.addEventListener('click', this.focusMainContent)
 
     const location = window.location.toString()
-    this.attr('showDemoNotice', location.indexOf('.a2jauthor.org') !== -1)
+    this.showDemoNotice = location.indexOf('.a2jauthor.org') !== -1
 
     this.checkPageExists()
 
@@ -67,16 +66,16 @@ let DesktopViewerVM = CanMap.extend('DesktopViewerVM', {
   },
 
   checkPageExists () {
-    const appState = this.attr('appState')
-    const interview = this.attr('interview')
+    const appState = this.appState
+    const interview = this.interview
 
     if (!appState || !interview) return
 
     const pageName = appState.page
 
     if (appState.view === 'pages') {
-      const page = interview.attr('pages').find(pageName)
-      this.attr('pageNotFound', _isUndefined(page))
+      const page = interview.pages.find(pageName)
+      this.pageNotFound = _isUndefined(page)
     }
   }
 })
@@ -89,7 +88,7 @@ export default Component.extend({
   helpers: {
     eval (str) {
       str = typeof str === 'function' ? str() : str
-      return this.attr('logic').eval(str)
+      return this.logic.eval(str)
     }
   },
 

--- a/src/desktop/desktop.js
+++ b/src/desktop/desktop.js
@@ -13,7 +13,7 @@ let DesktopViewerVM = CanMap.extend('DesktopViewerVM', {
     showDebugPanel: {},
     lang: {},
     logic: {},
-    rState: {},
+    appState: {},
     pState: {},
     mState: {},
     interview: {},
@@ -61,14 +61,14 @@ let DesktopViewerVM = CanMap.extend('DesktopViewerVM', {
   },
 
   checkPageExists () {
-    const rState = this.attr('rState')
+    const appState = this.attr('appState')
     const interview = this.attr('interview')
 
-    if (!rState || !interview) return
+    if (!appState || !interview) return
 
-    const pageName = rState.page
+    const pageName = appState.page
 
-    if (rState.view === 'pages') {
+    if (appState.view === 'pages') {
       const page = interview.attr('pages').find(pageName)
       this.attr('pageNotFound', _isUndefined(page))
     }
@@ -88,7 +88,7 @@ export default Component.extend({
   },
 
   events: {
-    '{rState} page': function () {
+    '{appState} page': function () {
       this.viewModel.checkPageExists()
     }
   },

--- a/src/desktop/desktop.stache
+++ b/src/desktop/desktop.stache
@@ -36,8 +36,7 @@
           pState:from="pState"
           mState:from="mState"
           interview:from="interview"
-          traceMessage:to="traceMessage"
-          modalContent:bind="modalContent" />
+          traceMessage:to="traceMessage" />
       </div><!-- app-content -->
 
       {{#if (authorBrandLogo)}}

--- a/src/desktop/desktop.stache
+++ b/src/desktop/desktop.stache
@@ -7,7 +7,7 @@
   <div class="app-container" role="main">
     {{#if (pageNotFound)}}
       <div class="alert alert-danger text-center" role="alert">
-        The page {{rState.page}} does not exist!
+        The page {{appState.page}} does not exist!
       </div>
     {{else}}
       {{#not(isMobile)}}
@@ -16,7 +16,7 @@
       <a2j-viewer-navigation
         lang:from="lang"
         logic:from="logic"
-        rState:from="rState"
+        appState:from="appState"
         resumeInterview:to="resumeInterview"
         interview:from="interview"
         showDemoNotice:from="showDemoNotice"
@@ -32,7 +32,7 @@
           resumeInterview:from="resumeInterview"
           lang:from="lang"
           logic:from="logic"
-          rState:from="rState"
+          appState:from="appState"
           pState:from="pState"
           mState:from="mState"
           interview:from="interview"
@@ -47,6 +47,6 @@
       {{/if}}
     {{/if}}
 
-    <app-footer rState:from="rState" />
+    <app-footer appState:from="appState" />
   </div><!-- app-container -->
 </div><!-- app-wrapper -->

--- a/src/desktop/desktop.stache
+++ b/src/desktop/desktop.stache
@@ -17,7 +17,7 @@
         lang:from="lang"
         logic:from="logic"
         appState:from="appState"
-        resumeInterview:to="resumeInterview"
+        resumeInterview:to="scope.resumeInterview"
         interview:from="interview"
         showDemoNotice:from="showDemoNotice"
         {{#if(scope.vm.authorCourthouseImage)}}courthouseImage:raw="{{normalizePath(mState.fileDataURL, scope.vm.authorCourthouseImage)}}"{{/if}} />
@@ -29,7 +29,7 @@
           remainingSteps:to="remainingSteps"
           maxDisplayedSteps:to="maxDisplayedSteps"
           showDebugPanel:from="showDebugPanel"
-          resumeInterview:from="resumeInterview"
+          resumeInterview:from="scope.resumeInterview"
           lang:from="lang"
           logic:from="logic"
           appState:from="appState"

--- a/src/desktop/navigation/navigation-test.js
+++ b/src/desktop/navigation/navigation-test.js
@@ -17,7 +17,7 @@ describe('<a2j-viewer-navigation>', function () {
     let vm
     let pages
     let visited
-    let rState
+    let appState
     let interview
     let logic
 
@@ -27,11 +27,11 @@ describe('<a2j-viewer-navigation>', function () {
       promise.then(function (_interview) {
         interview = _interview
         interview.attr('answers', { 'a2j interview incomplete tf': {values: []} })
-        rState = new AppState({ interview })
+        appState = new AppState({ interview })
         pages = interview.attr('pages')
-        visited = canReflect.getKeyValue(rState, 'visitedPages')
+        visited = canReflect.getKeyValue(appState, 'visitedPages')
         logic = new Logic({ interview })
-        vm = new ViewerNavigationVM({ rState, interview, logic })
+        vm = new ViewerNavigationVM({ appState, interview, logic })
 
         done()
       })
@@ -40,7 +40,7 @@ describe('<a2j-viewer-navigation>', function () {
     it('collects feedback form data', function () {
       // simulate user navigates to interview second page.
       let secondPage = pages.attr(1)
-      vm.rState.visitedPages.unshift(secondPage)
+      vm.appState.visitedPages.unshift(secondPage)
 
       assert.deepEqual(vm.feedbackData, {
         questionid: secondPage.attr('name'),
@@ -53,119 +53,119 @@ describe('<a2j-viewer-navigation>', function () {
     })
 
     it('canSaveAndExit', function () {
-      // true only if vm.rState.lastPageBeforeExit has a non falsy value
+      // true only if vm.appState.lastPageBeforeExit has a non falsy value
       // and interview.attr('exitPage') NOT being constants.qIDNOWHERE
-      vm.rState.lastPageBeforeExit = ''
+      vm.appState.lastPageBeforeExit = ''
       interview.attr('exitPage', constants.qIDNOWHERE)
       assert.isFalse(vm.canSaveAndExit)
 
       // lastPageBeforeExit having a value means you've already hit Save&Exit button
-      vm.rState.lastPageBeforeExit = '2-Name'
+      vm.appState.lastPageBeforeExit = '2-Name'
       interview.attr('exitPage', '1-Exit')
       assert.isFalse(vm.canSaveAndExit)
 
       // exit page assigned, but Save&Exit button not hit
-      vm.rState.lastPageBeforeExit = ''
+      vm.appState.lastPageBeforeExit = ''
       interview.attr('exitPage', '1-Exit')
       assert.isTrue(vm.canSaveAndExit)
     })
 
     it('canResumeInterview - whether Resume button should be enabled', function () {
-      vm.rState.lastPageBeforeExit = ''
+      vm.appState.lastPageBeforeExit = ''
       assert.isFalse(vm.canResumeInterview)
 
-      vm.rState.lastPageBeforeExit = '1-Intro'
+      vm.appState.lastPageBeforeExit = '1-Intro'
       assert.isTrue(vm.canResumeInterview)
     })
 
     it('resumeInterview', function () {
       // navigate to first page
       visited.unshift(pages.attr(0))
-      vm.rState.selectedPageIndex = 0
+      vm.appState.selectedPageIndex = 0
 
       // navigate to second page
       visited.unshift(pages.attr(1))
-      vm.rState.selectedPageIndex = 0
+      vm.appState.selectedPageIndex = 0
 
       // navigate to exit page by normal nav (not Author best practice)
       visited.unshift(pages.attr(2))
-      vm.rState.selectedPageIndex = 0
+      vm.appState.selectedPageIndex = 0
 
       vm.resumeInterview()
       assert.equal(visited.length, 2, 'should remove the normal nav page from visitedPages on Resume')
     })
 
     it('canNavigateBack - whether back button should be enabled', function () {
-      vm.rState.connectedCallback()
+      vm.appState.connectedCallback()
       // navigate to first page
       visited.unshift(pages.attr(0))
-      vm.rState.selectedPageIndex = 0
+      vm.appState.selectedPageIndex = 0
       assert.isFalse(vm.canNavigateBack, 'false if only one page visited')
 
       // navigate to second page
       visited.unshift(pages.attr(1))
-      vm.rState.selectedPageIndex = 0
+      vm.appState.selectedPageIndex = 0
       assert.isTrue(vm.canNavigateBack, 'true when on last page')
 
       // go back to first page
-      vm.rState.selectedPageIndex = 1
+      vm.appState.selectedPageIndex = 1
       assert.isFalse(vm.canNavigateBack, 'false when on first page')
     })
 
     it('canNavigateForward - whether next button should be enabled', function () {
-      vm.rState.connectedCallback()
+      vm.appState.connectedCallback()
       // navigate to first page
       visited.unshift(pages.attr(0))
-      vm.rState.selectedPageIndex = 0
+      vm.appState.selectedPageIndex = 0
       assert.isFalse(vm.canNavigateForward, 'false if only one page visited')
 
       // navigate to second page
       visited.unshift(pages.attr(1))
-      vm.rState.selectedPageIndex = 0
+      vm.appState.selectedPageIndex = 0
       assert.isFalse(vm.canNavigateForward, 'false when on the last page')
 
       // go back to first page
-      vm.rState.selectedPageIndex = 1
+      vm.appState.selectedPageIndex = 1
       assert.isTrue(vm.canNavigateForward, 'true when on the first page')
     })
 
     it('navigateBack', () => {
-      vm.rState.connectedCallback()
+      vm.appState.connectedCallback()
       visited.unshift(pages.attr(2))
       visited.unshift(pages.attr(1))
       visited.unshift(pages.attr(0))
 
       // select most recent page
-      vm.rState.selectedPageIndex = 0
+      vm.appState.selectedPageIndex = 0
 
       vm.navigateBack()
-      assert.equal(vm.rState.selectedPageIndex, 1, 'should navigate to middle page')
+      assert.equal(vm.appState.selectedPageIndex, 1, 'should navigate to middle page')
 
       vm.navigateBack()
-      assert.equal(vm.rState.selectedPageIndex, 2, 'should navigate to oldest page')
+      assert.equal(vm.appState.selectedPageIndex, 2, 'should navigate to oldest page')
     })
 
     it('navigateForward', () => {
-      vm.rState.connectedCallback()
+      vm.appState.connectedCallback()
       visited.unshift(pages.attr(2))
       visited.unshift(pages.attr(1))
       visited.unshift(pages.attr(0))
 
       // select oldest page
-      vm.rState.selectedPageIndex = 2
+      vm.appState.selectedPageIndex = 2
 
       vm.navigateForward()
-      assert.equal(vm.rState.selectedPageIndex, 1, 'should navigate to middle page')
+      assert.equal(vm.appState.selectedPageIndex, 1, 'should navigate to middle page')
 
       vm.navigateForward()
-      assert.equal(vm.rState.selectedPageIndex, 0, 'should navigate to most recent page')
+      assert.equal(vm.appState.selectedPageIndex, 0, 'should navigate to most recent page')
     })
 
     it('disableOption', () => {
       assert.equal(vm.disableOption(0), false, 'false by default even with index 0')
 
-      // saveAndExitActive is derived from vm.rState.lastPageBeforeExit having a value
-      vm.rState.lastPageBeforeExit = '2-Name'
+      // saveAndExitActive is derived from vm.appState.lastPageBeforeExit having a value
+      vm.appState.lastPageBeforeExit = '2-Name'
       assert.equal(vm.disableOption(0), false, 'false if index is 0 and saveAndExitActive is true')
       assert.equal(vm.disableOption(1), true, 'true if index is NOT 0 and saveAndExitActive is true')
     })
@@ -368,7 +368,7 @@ describe('<a2j-viewer-navigation>', function () {
     let pages
     let visited
     let interview
-    let rState
+    let appState
     let vm // eslint-disable-line
     let lang
     let logic
@@ -378,7 +378,7 @@ describe('<a2j-viewer-navigation>', function () {
 
       promise.then(function (_interview) {
         interview = _interview
-        rState = new AppState()
+        appState = new AppState()
         lang = {
           GoNext: 'Next',
           GoBack: 'Back',
@@ -389,19 +389,19 @@ describe('<a2j-viewer-navigation>', function () {
         }
 
         pages = interview.attr('pages')
-        visited = canReflect.getKeyValue(rState, 'visitedPages')
+        visited = canReflect.getKeyValue(appState, 'visitedPages')
         logic = new Logic({ interview })
-        vm = new ViewerNavigationVM({ rState, interview, lang, logic })
+        vm = new ViewerNavigationVM({ appState, interview, lang, logic })
 
         let frag = stache(
           `<a2j-viewer-navigation interview:from="interview"
-            rState:from="rState" lang:from="lang"
+            appState:from="appState" lang:from="lang"
             showDemoNotice:bind="showDemoNotice"
             logic:from="logic" />`
         )
 
         $('#test-area').html(frag({
-          rState,
+          appState,
           interview,
           lang,
           logic,
@@ -419,10 +419,10 @@ describe('<a2j-viewer-navigation>', function () {
       // navigate to a couple of pages
       visited.unshift(pages.attr(0))
       visited.unshift(pages.attr(1))
-      // connect listeners, specifically for rState.selectedPageIndexSet
+      // connect listeners, specifically for appState.selectedPageIndexSet
       vm.connectedCallback()
-      // fire rState event
-      vm.rState.dispatch('selectedPageIndexSet')
+      // fire appState event
+      vm.appState.dispatch('selectedPageIndexSet')
       setTimeout(() => {
         assert.equal($('select option').length, 2, 'just one page visited')
         done()
@@ -451,11 +451,11 @@ describe('<a2j-viewer-navigation>', function () {
 
     it('shows/hides Resume button based on vm.canSaveAndExit', function () {
       // turn off Resume button when saveAndExitActive is false even when lastPageBeforeExit has a value
-      vm.rState.lastPageBeforeExit = '1-Intro'
+      vm.appState.lastPageBeforeExit = '1-Intro'
       assert.equal($('.can-exit').length, 0, 'Resume button should not be rendered')
 
       // turn on Resume button when Exit button has been clicked
-      vm.rState.lastPageBeforeExit = '1-Intro'
+      vm.appState.lastPageBeforeExit = '1-Intro'
       assert.equal($('.can-resume').length, 1, 'Resume button should be rendered')
     })
 

--- a/src/desktop/navigation/navigation-test.js
+++ b/src/desktop/navigation/navigation-test.js
@@ -39,7 +39,7 @@ describe('<a2j-viewer-navigation>', function () {
 
     it('collects feedback form data', function () {
       // simulate user navigates to interview second page.
-      let secondPage = pages.attr(1)
+      let secondPage = pages[1]
       vm.appState.visitedPages.unshift(secondPage)
 
       assert.deepEqual(vm.feedbackData, {
@@ -80,15 +80,15 @@ describe('<a2j-viewer-navigation>', function () {
 
     it('resumeInterview', function () {
       // navigate to first page
-      visited.unshift(pages.attr(0))
+      visited.unshift(pages[0])
       vm.appState.selectedPageIndex = 0
 
       // navigate to second page
-      visited.unshift(pages.attr(1))
+      visited.unshift(pages[1])
       vm.appState.selectedPageIndex = 0
 
       // navigate to exit page by normal nav (not Author best practice)
-      visited.unshift(pages.attr(2))
+      visited.unshift(pages[2])
       vm.appState.selectedPageIndex = 0
 
       vm.resumeInterview()
@@ -98,12 +98,12 @@ describe('<a2j-viewer-navigation>', function () {
     it('canNavigateBack - whether back button should be enabled', function () {
       vm.appState.connectedCallback()
       // navigate to first page
-      visited.unshift(pages.attr(0))
+      visited.unshift(pages[0])
       vm.appState.selectedPageIndex = 0
       assert.isFalse(vm.canNavigateBack, 'false if only one page visited')
 
       // navigate to second page
-      visited.unshift(pages.attr(1))
+      visited.unshift(pages[1])
       vm.appState.selectedPageIndex = 0
       assert.isTrue(vm.canNavigateBack, 'true when on last page')
 
@@ -115,12 +115,12 @@ describe('<a2j-viewer-navigation>', function () {
     it('canNavigateForward - whether next button should be enabled', function () {
       vm.appState.connectedCallback()
       // navigate to first page
-      visited.unshift(pages.attr(0))
+      visited.unshift(pages[0])
       vm.appState.selectedPageIndex = 0
       assert.isFalse(vm.canNavigateForward, 'false if only one page visited')
 
       // navigate to second page
-      visited.unshift(pages.attr(1))
+      visited.unshift(pages[1])
       vm.appState.selectedPageIndex = 0
       assert.isFalse(vm.canNavigateForward, 'false when on the last page')
 
@@ -131,9 +131,9 @@ describe('<a2j-viewer-navigation>', function () {
 
     it('navigateBack', () => {
       vm.appState.connectedCallback()
-      visited.unshift(pages.attr(2))
-      visited.unshift(pages.attr(1))
-      visited.unshift(pages.attr(0))
+      visited.unshift(pages[2])
+      visited.unshift(pages[1])
+      visited.unshift(pages[0])
 
       // select most recent page
       vm.appState.selectedPageIndex = 0
@@ -147,9 +147,9 @@ describe('<a2j-viewer-navigation>', function () {
 
     it('navigateForward', () => {
       vm.appState.connectedCallback()
-      visited.unshift(pages.attr(2))
-      visited.unshift(pages.attr(1))
-      visited.unshift(pages.attr(0))
+      visited.unshift(pages[2])
+      visited.unshift(pages[1])
+      visited.unshift(pages[0])
 
       // select oldest page
       vm.appState.selectedPageIndex = 2
@@ -417,8 +417,8 @@ describe('<a2j-viewer-navigation>', function () {
 
     it('renders pages history dropdown', function (done) {
       // navigate to a couple of pages
-      visited.unshift(pages.attr(0))
-      visited.unshift(pages.attr(1))
+      visited.unshift(pages[0])
+      visited.unshift(pages[1])
       // connect listeners, specifically for appState.selectedPageIndexSet
       vm.connectedCallback()
       // fire appState event

--- a/src/desktop/navigation/navigation-test.js
+++ b/src/desktop/navigation/navigation-test.js
@@ -43,8 +43,8 @@ describe('<a2j-viewer-navigation>', function () {
       vm.appState.visitedPages.unshift(secondPage)
 
       assert.deepEqual(vm.feedbackData, {
-        questionid: secondPage.attr('name'),
-        questiontext: secondPage.attr('text'),
+        questionid: secondPage.name,
+        questiontext: secondPage.text,
         interviewid: interview.attr('version'),
         viewerversion: constants.A2JVersionNum,
         emailto: interview.attr('emailContact'),

--- a/src/desktop/navigation/navigation.js
+++ b/src/desktop/navigation/navigation.js
@@ -143,7 +143,7 @@ export let ViewerNavigationVM = DefineMap.extend({
     }
 
     if (answers) {
-      answers.attr('a2j interview incomplete tf').attr('values.1', true)
+      answers.varSet('a2j interview incomplete tf', true, 1)
     }
 
     this.appState.page = exitPage
@@ -165,7 +165,8 @@ export let ViewerNavigationVM = DefineMap.extend({
     this.appState.visitedPages.shift()
 
     if (answers) {
-      answers.attr('a2j interview incomplete tf').attr('values', [null])
+      // sets answer values prop to default value of [null]
+      answers.varSet('a2j interview incomplete tf', null, 0)
     }
     if (window._paq) {
       analytics.trackCustomEvent('Resume-Interview', 'to: ' + resumeTargetPageName)

--- a/src/desktop/navigation/navigation.js
+++ b/src/desktop/navigation/navigation.js
@@ -15,7 +15,7 @@ import isMobile from '~/src/util/is-mobile'
  */
 export let ViewerNavigationVM = DefineMap.extend({
   // passed in via stache bindings
-  rState: {},
+  appState: {},
   courthouseImage: {},
   interview: {},
   lang: {},
@@ -40,7 +40,7 @@ export let ViewerNavigationVM = DefineMap.extend({
    */
   visitedPages: {
     get () {
-      return this.rState.visitedPages
+      return this.appState.visitedPages
     }
   },
 
@@ -52,7 +52,7 @@ export let ViewerNavigationVM = DefineMap.extend({
    */
   canSaveAndExit: {
     get () {
-      return !this.rState.saveAndExitActive &&
+      return !this.appState.saveAndExitActive &&
       this.interview.attr('exitPage') !== constants.qIDNOWHERE
     }
   },
@@ -65,7 +65,7 @@ export let ViewerNavigationVM = DefineMap.extend({
    */
   canResumeInterview: {
     get () {
-      return this.rState.saveAndExitActive
+      return this.appState.saveAndExitActive
     }
   },
 
@@ -78,7 +78,7 @@ export let ViewerNavigationVM = DefineMap.extend({
   canNavigateBack: {
     get () {
       let totalPages = this.visitedPages.length
-      const canNavigateBack = totalPages > 1 && this.rState.selectedPageIndex < totalPages - 1 && !this.rState.saveAndExitActive
+      const canNavigateBack = totalPages > 1 && this.appState.selectedPageIndex < totalPages - 1 && !this.appState.saveAndExitActive
       return canNavigateBack
     }
   },
@@ -92,7 +92,7 @@ export let ViewerNavigationVM = DefineMap.extend({
   canNavigateForward: {
     get () {
       let totalPages = this.visitedPages.length
-      const canNavigateForward = totalPages > 1 && this.rState.selectedPageIndex > 0 && !this.rState.saveAndExitActive
+      const canNavigateForward = totalPages > 1 && this.appState.selectedPageIndex > 0 && !this.appState.saveAndExitActive
       return canNavigateForward
     }
   },
@@ -106,7 +106,7 @@ export let ViewerNavigationVM = DefineMap.extend({
   feedbackData: {
     get () {
       const pages = this.interview.attr('pages')
-      const page = pages.find(this.rState.selectedPageName)
+      const page = pages.find(this.appState.selectedPageName)
 
       if (!page) return {}
 
@@ -134,9 +134,9 @@ export let ViewerNavigationVM = DefineMap.extend({
   saveAndExit () {
     const answers = this.interview.attr('answers')
     const exitPage = this.interview.attr('exitPage')
-    const pageName = this.rState.selectedPageName
+    const pageName = this.appState.selectedPageName
 
-    this.rState.lastPageBeforeExit = pageName
+    this.appState.lastPageBeforeExit = pageName
 
     if (window._paq) {
       analytics.trackCustomEvent('Save&Exit', 'from: ' + pageName)
@@ -146,8 +146,8 @@ export let ViewerNavigationVM = DefineMap.extend({
       answers.attr('a2j interview incomplete tf').attr('values.1', true)
     }
 
-    this.rState.page = exitPage
-    this.rState.selectedPageIndex = 0
+    this.appState.page = exitPage
+    this.appState.selectedPageIndex = 0
   },
 
   /**
@@ -158,11 +158,11 @@ export let ViewerNavigationVM = DefineMap.extend({
    */
   resumeInterview () {
     const answers = this.interview.answers
-    const resumeTargetPageName = this.rState.lastPageBeforeExit
-    this.rState.lastPageBeforeExit = null
+    const resumeTargetPageName = this.appState.lastPageBeforeExit
+    this.appState.lastPageBeforeExit = null
 
     // Special Exit page should only show in My Progress while on that page
-    this.rState.visitedPages.shift()
+    this.appState.visitedPages.shift()
 
     if (answers) {
       answers.attr('a2j interview incomplete tf').attr('values', [null])
@@ -171,7 +171,7 @@ export let ViewerNavigationVM = DefineMap.extend({
       analytics.trackCustomEvent('Resume-Interview', 'to: ' + resumeTargetPageName)
     }
     if (resumeTargetPageName) {
-      this.rState.page = resumeTargetPageName
+      this.appState.page = resumeTargetPageName
     }
   },
 
@@ -183,7 +183,7 @@ export let ViewerNavigationVM = DefineMap.extend({
    */
   navigateBack () {
     if (this.canNavigateBack) {
-      this.rState.selectedPageIndex = this.rState.selectedPageIndex + 1
+      this.appState.selectedPageIndex = this.appState.selectedPageIndex + 1
     }
   },
 
@@ -195,7 +195,7 @@ export let ViewerNavigationVM = DefineMap.extend({
    */
   navigateForward () {
     if (this.canNavigateForward) {
-      this.rState.selectedPageIndex = this.rState.selectedPageIndex - 1
+      this.appState.selectedPageIndex = this.appState.selectedPageIndex - 1
     }
   },
 
@@ -206,7 +206,7 @@ export let ViewerNavigationVM = DefineMap.extend({
    * Used to disable My Progress options when saveAndExit is active
    */
   disableOption (index) {
-    if (index !== 0 && this.rState.saveAndExitActive) {
+    if (index !== 0 && this.appState.saveAndExitActive) {
       return true
     }
     return false
@@ -382,7 +382,7 @@ export let ViewerNavigationVM = DefineMap.extend({
     // update the selectedPageIndex
     const myProgressSelect = document.getElementById('myProgressSelect')
     const updateAppStateSelectedPageIndex = (ev) => {
-      vm.rState.selectedPageIndex = myProgressSelect.selectedIndex
+      vm.appState.selectedPageIndex = myProgressSelect.selectedIndex
     }
     myProgressSelect.addEventListener('change', updateAppStateSelectedPageIndex)
 
@@ -392,13 +392,13 @@ export let ViewerNavigationVM = DefineMap.extend({
       vm.myProgressOptions.update(this.buildOptions(this.visitedPages))
     }
 
-    // rebuild options on selectedPageIndexSet dispatched on app-state level rState
+    // rebuild options on selectedPageIndexSet dispatched on app-state level appState
     // covers normal Continue button and navigation via this component, back/next or dropdown select
-    vm.rState.listenTo('selectedPageIndexSet', updateMyProgressOptions)
+    vm.appState.listenTo('selectedPageIndexSet', updateMyProgressOptions)
 
     // cleanup
     return () => {
-      vm.rState.stopListening('selectedPageIndexSet', updateMyProgressOptions)
+      vm.appState.stopListening('selectedPageIndexSet', updateMyProgressOptions)
       myProgressSelect.removeEventListener('change', updateAppStateSelectedPageIndex)
     }
   }
@@ -413,8 +413,8 @@ export let ViewerNavigationVM = DefineMap.extend({
  *
  * @codestart
  * <a2j-viewer-navigation>
- *   {(selected-page-name)}="rState.page"
- *   {(app-state)}="rState"
+ *   {(selected-page-name)}="appState.page"
+ *   {(app-state)}="appState"
  *   {(interview)}="interview">
  * </a2j-viewer-navigation>
  * @codeend

--- a/src/desktop/navigation/navigation.js
+++ b/src/desktop/navigation/navigation.js
@@ -111,8 +111,8 @@ export let ViewerNavigationVM = DefineMap.extend({
       if (!page) return {}
 
       return {
-        questionid: page.attr('name'),
-        questiontext: page.attr('text'),
+        questionid: page.name,
+        questiontext: page.text,
         interviewid: this.interview.attr('version'),
         viewerversion: constants.A2JVersionNum,
         emailto: this.interview.attr('emailContact'),

--- a/src/desktop/navigation/navigation.stache
+++ b/src/desktop/navigation/navigation.stache
@@ -40,7 +40,7 @@
             role="listbox"
             id="myProgressSelect"
             class="form-control"
-            value:from="this.rState.selectedPageIndex">
+            value:from="this.appState.selectedPageIndex">
             {{#for(option of myProgressOptions)}}
               <option value:from="scope.index" disabled:from="this.disableOption(scope.index)">
                 {{{option}}}

--- a/src/desktop/steps/steps-test.html
+++ b/src/desktop/steps/steps-test.html
@@ -8,7 +8,7 @@
     <div id="mocha"></div>
     <div id="test-area"></div>
 
-    <script src="../../node_modules/steal/steal.js"
+    <script src="../../../node_modules/steal/steal.js"
       data-mocha="bdd"
       data-main="~/src/desktop/steps/steps-test"></script>
   </body>

--- a/src/desktop/steps/steps-test.js
+++ b/src/desktop/steps/steps-test.js
@@ -345,7 +345,7 @@ describe('<a2j-viewer-steps>', function () {
       const answers = interview.attr('answers')
 
       // user has not set their gender
-      answers.attr('user gender', {
+      answers.varSet('user gender', {
         name: 'user gender',
         values: [null]
       })
@@ -360,7 +360,7 @@ describe('<a2j-viewer-steps>', function () {
         const answers = interview.attr('answers')
 
         // user set her gender.
-        answers.attr('user gender', {
+        answers.varSet('user gender', {
           name: 'user gender',
           values: [null, 'f']
         })

--- a/src/desktop/steps/steps-test.js
+++ b/src/desktop/steps/steps-test.js
@@ -23,7 +23,7 @@ describe('<a2j-viewer-steps>', function () {
     let currentPage
 
     beforeEach(() => {
-      const rState = new AppState()
+      const appState = new AppState()
 
       const logicStub = new CanMap({
         exec: $.noop,
@@ -69,13 +69,13 @@ describe('<a2j-viewer-steps>', function () {
         answers
       }
 
-      appStateTeardown = rState.connectedCallback()
-      rState.interview = interview
-      rState.logic = logicStub
-      rState.traceMessage = new TraceMessage()
-      rState.page = '01-Introduction'
+      appStateTeardown = appState.connectedCallback()
+      appState.interview = interview
+      appState.logic = logicStub
+      appState.traceMessage = new TraceMessage()
+      appState.page = '01-Introduction'
 
-      vm = new ViewerStepsVM({ rState })
+      vm = new ViewerStepsVM({ appState })
       vm.attr({ interview })
     })
 
@@ -303,10 +303,10 @@ describe('<a2j-viewer-steps>', function () {
 
       const traceMessage = new TraceMessage()
       const mState = new CanMap()
-      const rState = new AppState({ traceMessage })
-      appStateTeardown = rState.connectedCallback()
-      rState.page = interview.attr('firstPage')
-      rState.interview = interview
+      const appState = new AppState({ traceMessage })
+      appStateTeardown = appState.connectedCallback()
+      appState.page = interview.attr('firstPage')
+      appState.interview = interview
 
       const logic = new Logic({ interview })
 
@@ -318,14 +318,14 @@ describe('<a2j-viewer-steps>', function () {
 
       const frag = stache(
         `<a2j-viewer-steps
-        rState:from="rState"
+        appState:from="appState"
         mState:from="mState"
         interview:from="interview"
         logic:from="logic"
         lang:from="langStub"/>`
       )
 
-      $('#test-area').html(frag({ rState, interview, mState, logic, langStub }))
+      $('#test-area').html(frag({ appState, interview, mState, logic, langStub }))
       vm = $('a2j-viewer-steps')[0].viewModel
     })
 

--- a/src/desktop/steps/steps-test.js
+++ b/src/desktop/steps/steps-test.js
@@ -1,10 +1,13 @@
 import CanMap from 'can-map'
+import DefineMap from 'can-define/map/map'
 import { assert } from 'chai'
 import _round from 'lodash/round'
 import _assign from 'lodash/assign'
 import stache from 'can-stache'
 import AppState from '~/src/models/app-state'
 import Interview from '~/src/models/interview'
+import Answers from '~/src/models/answers'
+import Page from '~/src/models/page'
 import Logic from '~/src/mobile/util/logic'
 import TraceMessage from '@caliorg/a2jdeps/models/trace-message'
 import $ from 'jquery'
@@ -20,11 +23,8 @@ describe('<a2j-viewer-steps>', function () {
   describe('ViewModel', function () {
     let vm
     let appStateTeardown
-    let currentPage
 
     beforeEach(() => {
-      const appState = new AppState()
-
       const logicStub = new CanMap({
         exec: $.noop,
         infinite: {
@@ -40,26 +40,30 @@ describe('<a2j-viewer-steps>', function () {
         eval: sinon.spy()
       })
 
-      currentPage = new CanMap({
-        step: {
-          number: '2',
-          text: 'Audio Test'
-        }
-      })
-
-      const answers = new CanMap({
+      const answers = new Answers({
         'a2j step 0': {
           name: 'A2J Step 0',
+          values: [null]
+        },
+
+        'user gender': {
+          name: 'user gender',
           values: [null]
         }
       })
 
-      const interview = new CanMap({
-        getPageByName () {
-          return currentPage
-        },
+      const interview = new Interview({
+        avatarGender: '',
+        pages: [
+          new Page({name: 'fooPage', step: { number: '1', text: 'Foo Test' }}),
+          new Page({name: 'audioTest', step: { number: '2', text: 'Audio Test' }}),
+          new Page({name: 'graphicTest', step: { number: '3', text: 'Graphic Test' }}),
+          new Page({name: 'graphicWithAudioTest', step: { number: '4', text: 'Graphic with Audio Test' }}),
+          new Page({name: 'VideoTest', step: { number: '5', text: 'Video' }})
+        ],
 
         steps: [
+          { number: '1', text: 'Foo Test' },
           { number: '2', text: 'Audio Test' },
           { number: '3', text: 'Graphic Test' },
           { number: '4', text: 'Graphic with Audio Test' },
@@ -69,11 +73,12 @@ describe('<a2j-viewer-steps>', function () {
         answers
       })
 
+      const appState = new AppState()
       appStateTeardown = appState.connectedCallback()
       appState.interview = interview
       appState.logic = logicStub
       appState.traceMessage = new TraceMessage()
-      appState.page = '01-Introduction'
+      appState.page = 'audioTest'
 
       vm = new ViewerStepsVM({ appState, interview })
     })
@@ -92,13 +97,13 @@ describe('<a2j-viewer-steps>', function () {
       const step = vm.interview.attr('steps.0')
       const stepVar = vm.interview.attr('answers.a2j step 0')
 
-      assert.equal(vm.getTextForStep(step), 'Audio Test', 'show default step sign text')
+      assert.equal(vm.getTextForStep(step), 'Foo Test', 'show default step sign text')
       // update matching step var
-      stepVar.attr('values.1', 'New Sign Text')
+      stepVar.values.set(1, 'New Sign Text')
       assert.equal(vm.getTextForStep(step), 'New Sign Text', 'Authors can set new sign displayText')
       // clear custom value
-      stepVar.values[1] = ''
-      assert.equal(vm.getTextForStep(step), 'Audio Test', 'should restore text when step var set to empty string')
+      stepVar.values.set(1, '')
+      assert.equal(vm.getTextForStep(step), 'Foo Test', 'should restore text when step var set to empty string')
     })
 
     it('getStepIndex', () => {
@@ -109,7 +114,7 @@ describe('<a2j-viewer-steps>', function () {
 
     it('truncateText', () => {
       const step = vm.interview.attr('steps.0')
-      assert.equal(vm.truncateText(step.text), 'Audio Test', 'should not change short text')
+      assert.equal(vm.truncateText(step.text), 'Foo Test', 'should not change short text')
 
       step.attr('text', 'slightly longer text with a space as the 51st char that gets truncated')
 
@@ -149,9 +154,7 @@ describe('<a2j-viewer-steps>', function () {
     })
 
     it('maxDisplayedSteps', () => {
-      vm.interview.attr('steps', [1, 2, 3, 4, 5])
       vm.sidewalkHeight = 50
-
       assert.equal(vm.maxDisplayedSteps, 1, 'show 1 step when sidewalk < 100px')
 
       vm.sidewalkHeight = 100
@@ -172,8 +175,8 @@ describe('<a2j-viewer-steps>', function () {
       vm.sidewalkHeight = 750
       assert.equal(vm.maxDisplayedSteps, 5, 'show 5 steps when sidewalk is 750px or above')
 
-      vm.interview.attr('steps').length = 4
-      assert.equal(vm.maxDisplayedSteps, 4, 'never show more steps than interview has')
+      // vm.interview.attr('steps').length = 4
+      // assert.equal(vm.maxDisplayedSteps, 4, 'never show more steps than interview has')
     })
 
     it('guideAvatarSkinTone', () => {
@@ -194,17 +197,6 @@ describe('<a2j-viewer-steps>', function () {
     })
 
     it('showUserAvatar / guideAvatarFacingDirection', () => {
-      currentPage = new CanMap()
-
-      vm.assign({
-        interview: new CanMap({
-          avatarGender: '',
-          getPageByName () {
-            return currentPage
-          }
-        })
-      })
-
       assert.ok(!vm.showUserAvatar, 'should not show user avatar')
       assert.equal(
         vm.guideAvatarFacingDirection,
@@ -212,8 +204,8 @@ describe('<a2j-viewer-steps>', function () {
         'should show guide avatar facing front'
       )
 
-      vm.interview.attr('avatarGender', 'gender')
-      currentPage.attr('hasUserGenderOrAvatarField', true)
+      vm.interview.attr('answers').varSet('user gender', 'Female')
+      vm.currentPage.fields = [ {name: 'user gender'} ]
       assert.ok(!vm.showUserAvatar, 'should not show user avatar when current page has the user gender field')
       assert.equal(
         vm.guideAvatarFacingDirection,
@@ -221,8 +213,8 @@ describe('<a2j-viewer-steps>', function () {
         'should still show guide avatar facing front'
       )
 
-      currentPage.attr('hasUserGenderOrAvatarField', false)
-      assert.ok(!!vm.showUserAvatar, 'should show user avatar when user has a gender')
+      vm.currentPage.fields = [ {name: 'foo'} ]
+      assert.ok(!!vm.showUserAvatar, 'should show user avatar when user has a gender and not on gender field page')
       assert.equal(
         vm.guideAvatarFacingDirection,
         'right',
@@ -299,6 +291,7 @@ describe('<a2j-viewer-steps>', function () {
       const parsedData = Interview.parseModel(rawData)
 
       interview = new Interview(parsedData)
+      interview.attr('answers').varCreate('user gender', 'MC', false)
 
       const traceMessage = new TraceMessage()
       const mState = new CanMap()
@@ -309,7 +302,7 @@ describe('<a2j-viewer-steps>', function () {
 
       const logic = new Logic({ interview })
 
-      let langStub = new CanMap({
+      let langStub = new DefineMap({
         MonthNamesShort: 'Jan, Feb',
         MonthNamesLong: 'January, February',
         LearnMore: 'Learn More'
@@ -342,34 +335,22 @@ describe('<a2j-viewer-steps>', function () {
     })
 
     it('renders only guide avatar if "avatarGender" is unknown', function (done) {
-      const answers = interview.attr('answers')
-
-      // user has not set their gender
-      answers.varSet('user gender', {
-        name: 'user gender',
-        values: [null]
-      })
       assert.isUndefined(interview.attr('avatarGender'))
 
       F('a2j-viewer-avatar').size(1)
       F(done)
     })
 
-    it('renders both client and guide avatars if "avatarGender" is known',
-      function (done) {
-        const answers = interview.attr('answers')
+    it('renders both client and guide avatars if "avatarGender" is known', function (done) {
+      const answers = vm.interview.attr('answers')
 
-        // user set her gender.
-        answers.varSet('user gender', {
-          name: 'user gender',
-          values: [null, 'f']
-        })
+      // user set her gender.
+      answers.varSet('user gender', 'f', 1)
 
-        assert.equal(interview.attr('avatarGender'), 'female')
+      assert.equal(interview.attr('avatarGender'), 'female')
 
-        F('a2j-viewer-avatar').size(2)
-        F(done)
-      }
-    )
+      F('a2j-viewer-avatar').size(2)
+      F(done)
+    })
   })
 })

--- a/src/desktop/steps/steps-test.js
+++ b/src/desktop/steps/steps-test.js
@@ -54,7 +54,7 @@ describe('<a2j-viewer-steps>', function () {
         }
       })
 
-      const interview = {
+      const interview = new CanMap({
         getPageByName () {
           return currentPage
         },
@@ -67,7 +67,7 @@ describe('<a2j-viewer-steps>', function () {
         ],
 
         answers
-      }
+      })
 
       appStateTeardown = appState.connectedCallback()
       appState.interview = interview
@@ -75,8 +75,7 @@ describe('<a2j-viewer-steps>', function () {
       appState.traceMessage = new TraceMessage()
       appState.page = '01-Introduction'
 
-      vm = new ViewerStepsVM({ appState })
-      vm.attr({ interview })
+      vm = new ViewerStepsVM({ appState, interview })
     })
 
     afterEach(() => {
@@ -84,32 +83,32 @@ describe('<a2j-viewer-steps>', function () {
     })
 
     it('hasAvatarPicker', () => {
-      vm.attr('currentPage.fields', [{ type: 'text' }, { type: 'useravatar' }])
+      vm.currentPage.fields = [{ type: 'text' }, { type: 'useravatar' }]
 
-      assert.isTrue(vm.attr('hasAvatarPicker'), 'should detect if fields contains avatarpicker field type')
+      assert.isTrue(vm.hasAvatarPicker, 'should detect if fields contains avatarpicker field type')
     })
 
     it('getTextForStep', () => {
-      const step = vm.attr('interview.steps.0')
-      const stepVar = vm.attr('interview.answers.a2j step 0')
+      const step = vm.interview.attr('steps.0')
+      const stepVar = vm.interview.attr('answers.a2j step 0')
 
       assert.equal(vm.getTextForStep(step), 'Audio Test', 'show default step sign text')
       // update matching step var
       stepVar.attr('values.1', 'New Sign Text')
       assert.equal(vm.getTextForStep(step), 'New Sign Text', 'Authors can set new sign displayText')
       // clear custom value
-      stepVar.attr('values.1', '')
+      stepVar.values[1] = ''
       assert.equal(vm.getTextForStep(step), 'Audio Test', 'should restore text when step var set to empty string')
     })
 
     it('getStepIndex', () => {
-      const step = vm.attr('interview.steps.2')
+      const step = vm.interview.attr('steps.2')
 
       assert.equal(vm.getStepIndex(step), 2, 'it did not return the correct index for the step')
     })
 
     it('truncateText', () => {
-      const step = vm.attr('interview.steps.0')
+      const step = vm.interview.attr('steps.0')
       assert.equal(vm.truncateText(step.text), 'Audio Test', 'should not change short text')
 
       step.attr('text', 'slightly longer text with a space as the 51st char that gets truncated')
@@ -137,146 +136,146 @@ describe('<a2j-viewer-steps>', function () {
       ]
 
       assert.deepEqual(
-        vm.attr('nextSteps').serialize(),
+        vm.nextSteps.serialize(),
         expectedNextSteps,
         'it should match expected fixtures'
       )
 
       assert.equal(
-        vm.attr('remainingSteps'),
+        vm.remainingSteps,
         expectedNextSteps.length,
         'there should be 3 steps remaining'
       )
     })
 
     it('maxDisplayedSteps', () => {
-      vm.attr('interview.steps', [1, 2, 3, 4, 5])
-      vm.attr('sidewalkHeight', 50)
+      vm.interview.attr('steps', [1, 2, 3, 4, 5])
+      vm.sidewalkHeight = 50
 
-      assert.equal(vm.attr('maxDisplayedSteps'), 1, 'show 1 step when sidewalk < 100px')
+      assert.equal(vm.maxDisplayedSteps, 1, 'show 1 step when sidewalk < 100px')
 
-      vm.attr('sidewalkHeight', 100)
-      assert.equal(vm.attr('maxDisplayedSteps'), 2, 'show 2 steps when sidewalk is 100-450px')
-      vm.attr('sidewalkHeight', 449)
-      assert.equal(vm.attr('maxDisplayedSteps'), 2, 'show 2 steps when sidewalk is 100-449px')
+      vm.sidewalkHeight = 100
+      assert.equal(vm.maxDisplayedSteps, 2, 'show 2 steps when sidewalk is 100-450px')
+      vm.sidewalkHeight = 449
+      assert.equal(vm.maxDisplayedSteps, 2, 'show 2 steps when sidewalk is 100-449px')
 
-      vm.attr('sidewalkHeight', 450)
-      assert.equal(vm.attr('maxDisplayedSteps'), 3, 'show 3 steps when sidewalk is 450-549')
-      vm.attr('sidewalkHeight', 549)
-      assert.equal(vm.attr('maxDisplayedSteps'), 3, 'show 3 steps when sidewalk is 450-549')
+      vm.sidewalkHeight = 450
+      assert.equal(vm.maxDisplayedSteps, 3, 'show 3 steps when sidewalk is 450-549')
+      vm.sidewalkHeight = 549
+      assert.equal(vm.maxDisplayedSteps, 3, 'show 3 steps when sidewalk is 450-549')
 
-      vm.attr('sidewalkHeight', 550)
-      assert.equal(vm.attr('maxDisplayedSteps'), 4, 'show 4 steps when sidewalk is 550-749')
-      vm.attr('sidewalkHeight', 749)
-      assert.equal(vm.attr('maxDisplayedSteps'), 4, 'show 4 steps when sidewalk is 550-749')
+      vm.sidewalkHeight = 550
+      assert.equal(vm.maxDisplayedSteps, 4, 'show 4 steps when sidewalk is 550-749')
+      vm.sidewalkHeight = 749
+      assert.equal(vm.maxDisplayedSteps, 4, 'show 4 steps when sidewalk is 550-749')
 
-      vm.attr('sidewalkHeight', 750)
-      assert.equal(vm.attr('maxDisplayedSteps'), 5, 'show 5 steps when sidewalk is 750px or above')
+      vm.sidewalkHeight = 750
+      assert.equal(vm.maxDisplayedSteps, 5, 'show 5 steps when sidewalk is 750px or above')
 
-      vm.attr('interview.steps.length', 4)
-      assert.equal(vm.attr('maxDisplayedSteps'), 4, 'never show more steps than interview has')
+      vm.interview.attr('steps').length = 4
+      assert.equal(vm.maxDisplayedSteps, 4, 'never show more steps than interview has')
     })
 
     it('guideAvatarSkinTone', () => {
-      vm.attr({
-        interview: {},
-        mState: {}
+      vm.assign({
+        interview: new CanMap(),
+        mState: new CanMap()
       })
 
-      vm.attr('interview.avatarSkinTone', 'avatar')
-      assert.equal(vm.attr('guideAvatarSkinTone'), 'avatar', 'should use interview skin tone if set')
+      vm.interview.attr('avatarSkinTone', 'avatar')
+      assert.equal(vm.guideAvatarSkinTone, 'avatar', 'should use interview skin tone if set')
 
-      vm.attr('interview.avatarSkinTone', '')
-      vm.attr('mState.avatarSkinTone', 'global')
-      assert.equal(vm.attr('guideAvatarSkinTone'), 'global', 'should use global skin tone if set')
+      vm.interview.attr('avatarSkinTone', '')
+      vm.mState.attr('avatarSkinTone', 'global')
+      assert.equal(vm.guideAvatarSkinTone, 'global', 'should use global skin tone if set')
 
-      vm.attr('interview.avatarSkinTone', 'avatar')
-      assert.equal(vm.attr('guideAvatarSkinTone'), 'global', 'should use global skin tone if both are set')
+      vm.interview.attr('avatarSkinTone', 'avatar')
+      assert.equal(vm.guideAvatarSkinTone, 'global', 'should use global skin tone if both are set')
     })
 
     it('showUserAvatar / guideAvatarFacingDirection', () => {
       currentPage = new CanMap()
 
-      vm.attr({
-        interview: {
+      vm.assign({
+        interview: new CanMap({
           avatarGender: '',
           getPageByName () {
             return currentPage
           }
-        }
+        })
       })
 
-      assert.ok(!vm.attr('showUserAvatar'), 'should not show user avatar')
+      assert.ok(!vm.showUserAvatar, 'should not show user avatar')
       assert.equal(
-        vm.attr('guideAvatarFacingDirection'),
+        vm.guideAvatarFacingDirection,
         'front',
         'should show guide avatar facing front'
       )
 
-      vm.attr('interview.avatarGender', 'gender')
+      vm.interview.attr('avatarGender', 'gender')
       currentPage.attr('hasUserGenderOrAvatarField', true)
-      assert.ok(!vm.attr('showUserAvatar'), 'should not show user avatar when current page has the user gender field')
+      assert.ok(!vm.showUserAvatar, 'should not show user avatar when current page has the user gender field')
       assert.equal(
-        vm.attr('guideAvatarFacingDirection'),
+        vm.guideAvatarFacingDirection,
         'front',
         'should still show guide avatar facing front'
       )
 
       currentPage.attr('hasUserGenderOrAvatarField', false)
-      assert.ok(!!vm.attr('showUserAvatar'), 'should show user avatar when user has a gender')
+      assert.ok(!!vm.showUserAvatar, 'should show user avatar when user has a gender')
       assert.equal(
-        vm.attr('guideAvatarFacingDirection'),
+        vm.guideAvatarFacingDirection,
         'right',
         'should show guide avatar facing right'
       )
     })
 
     it('sidewalkLength', () => {
-      vm.attr('sidewalkHeight', 4)
-      vm.attr('sidewalkWidth', 3)
-      assert.equal(vm.attr('sidewalkLength'), 5)
+      vm.sidewalkHeight = 4
+      vm.sidewalkWidth = 3
+      assert.equal(vm.sidewalkLength, 5)
     })
 
     it('sidewalkAngleA', () => {
-      vm.attr('sidewalkHeight', 600)
+      vm.sidewalkHeight = 600
 
       // set sidewalkLength to 1200 by doing 1200^2 - 600^2 = sidewalkWidth^2
-      vm.attr('sidewalkWidth', Math.pow(Math.pow(1200, 2) - Math.pow(600, 2), 0.5))
+      vm.sidewalkWidth = Math.pow(Math.pow(1200, 2) - Math.pow(600, 2), 0.5)
 
       // angle A is then PI/6 radians (30 degrees)
-      assert.equal(_round(vm.attr('sidewalkAngleA'), 5), _round(Math.PI / 6, 5))
+      assert.equal(_round(vm.sidewalkAngleA, 5), _round(Math.PI / 6, 5))
     })
 
     it('guideBubbleTallerThanAvatar', () => {
-      vm.attr('guideBubbleHeight', 100)
-      vm.attr('avatarHeight', 100)
-      assert.equal(vm.attr('guideBubbleTallerThanAvatar'), false, 'false')
+      vm.guideBubbleHeight = 100
+      vm.avatarHeight = 100
+      assert.equal(vm.guideBubbleTallerThanAvatar, false, 'false')
 
-      vm.attr('avatarHeight', 99)
-      assert.equal(vm.attr('guideBubbleTallerThanAvatar'), true, 'true')
+      vm.avatarHeight = 99
+      assert.equal(vm.guideBubbleTallerThanAvatar, true, 'true')
     })
 
     it('userBubbleTallerThanAvatar', () => {
-      vm.attr('clientBubbleHeight', 100)
-      vm.attr('avatarHeight', 100)
-      assert.equal(vm.attr('userBubbleTallerThanAvatar'), false, 'false')
+      vm.clientBubbleHeight = 100
+      vm.avatarHeight = 100
+      assert.equal(vm.userBubbleTallerThanAvatar, false, 'false')
 
-      vm.attr('avatarHeight', 99)
-      assert.equal(vm.attr('userBubbleTallerThanAvatar'), true, 'true')
+      vm.avatarHeight = 99
+      assert.equal(vm.userBubbleTallerThanAvatar, true, 'true')
     })
 
     it('minusHeader', () => {
-      vm.attr('bodyHeight', 100)
-      vm.attr('sidewalkHeight', 50)
-      assert.equal(vm.attr('minusHeader'), 25)
+      vm.bodyHeight = 100
+      vm.sidewalkHeight = 50
+      assert.equal(vm.minusHeader, 25)
     })
 
     it('getStepWidth()', () => {
-      vm.attr('avatarOffsetTop', 211)
-      vm.attr('minusHeader', 98)
-      vm.attr('bodyHeight', 768)
-      vm.attr('sidewalkHeight', 573)
-      vm.attr('sidewalkWidth', 512)
+      vm.avatarOffsetTop = 211
+      vm.minusHeader = 98
+      vm.bodyHeight = 768
+      vm.sidewalkHeight = 573
+      vm.sidewalkWidth = 512
 
       assert.equal(Math.ceil(vm.getStepWidth(true)), 303)
       assert.equal(Math.ceil(vm.getStepWidth(false, 378.156)), 195)

--- a/src/desktop/steps/steps.js
+++ b/src/desktop/steps/steps.js
@@ -33,7 +33,7 @@ export let ViewerStepsVM = CanMap.extend('ViewerStepsVM', {
     showDebugPanel: {},
     lang: {},
     logic: {},
-    rState: {},
+    appState: {},
     pState: {},
     mState: {},
     interview: {},
@@ -47,7 +47,7 @@ export let ViewerStepsVM = CanMap.extend('ViewerStepsVM', {
      */
     userAvatar: {
       get () {
-        return this.attr('rState').userAvatar
+        return this.attr('appState').userAvatar
       }
     },
 
@@ -71,7 +71,7 @@ export let ViewerStepsVM = CanMap.extend('ViewerStepsVM', {
      */
     currentPage: {
       get () {
-        return this.attr('rState').currentPage
+        return this.attr('appState').currentPage
       }
     },
 
@@ -527,7 +527,7 @@ export let ViewerStepsVM = CanMap.extend('ViewerStepsVM', {
 
   fireLearnMoreModal () {
     const pages = this.attr('interview.pages')
-    const pageName = this.attr('rState.page')
+    const pageName = this.attr('appState.page')
 
     if (pages && pageName) {
       const page = pages.find(pageName)
@@ -560,7 +560,7 @@ export let ViewerStepsVM = CanMap.extend('ViewerStepsVM', {
         const userAvatar = answers.attr('user avatar')
         const previousUserAvatar = userAvatar.attr('values.1')
         if (previousUserAvatar) {
-          vm.attr('rState').userAvatar.update(JSON.parse(previousUserAvatar))
+          vm.attr('appState').userAvatar.update(JSON.parse(previousUserAvatar))
         }
       }
     }

--- a/src/desktop/steps/steps.js
+++ b/src/desktop/steps/steps.js
@@ -29,7 +29,11 @@ export let ViewerStepsVM = DefineMap.extend('ViewerStepsVM', {
   lang: {},
   logic: {},
   interview: {},
-  modalContent: {},
+  modalContent: {
+    get () {
+      return this.appState.modalContent
+    }
+  },
   // passed up from pages-stache
   traceMessage: {},
 
@@ -545,6 +549,7 @@ export let ViewerStepsVM = DefineMap.extend('ViewerStepsVM', {
         videoURL: page.helpVideoURL,
         helpReader: page.helpReader
       })
+      $('#pageModal').modal('show')
     }
   },
 

--- a/src/desktop/steps/steps.js
+++ b/src/desktop/steps/steps.js
@@ -533,7 +533,7 @@ export let ViewerStepsVM = DefineMap.extend('ViewerStepsVM', {
         analytics.trackCustomEvent('Learn-More', 'from: ' + pageName, page.learn)
       }
 
-      this.modalContent = {
+      this.modalContent.assign({
         // name undefined prevents stache warnings
         answerName: undefined,
         title: page.learn,
@@ -544,7 +544,7 @@ export let ViewerStepsVM = DefineMap.extend('ViewerStepsVM', {
         audioURL: page.helpAudioURL,
         videoURL: page.helpVideoURL,
         helpReader: page.helpReader
-      }
+      })
     }
   },
 

--- a/src/desktop/steps/steps.js
+++ b/src/desktop/steps/steps.js
@@ -15,7 +15,7 @@ import canReflect from 'can-reflect'
 stache.registerPartial('learn-more-tpl', learnMoreTemplate)
 
 /**
- * @property {can.Map} steps.ViewModel
+ * @property {DefineMap} steps.ViewModel
  * @parent <a2j-viewer-steps>
  *
  * `<a2j-viewer-steps>`'s viewModel.
@@ -34,7 +34,7 @@ export let ViewerStepsVM = DefineMap.extend('ViewerStepsVM', {
   traceMessage: {},
 
   /**
-   * @property {can.DefineMap} steps.ViewModel.prototype.userAvatar userAvatar
+   * @property {DefineMap} steps.ViewModel.prototype.userAvatar userAvatar
    * @parent steps.ViewModel
    *
    * current User Avatar in interview
@@ -46,7 +46,7 @@ export let ViewerStepsVM = DefineMap.extend('ViewerStepsVM', {
   },
 
   /**
-   * @property {can.DefineMap} steps.ViewModel.prototype.hasWheelchair hasWheelchair
+   * @property {DefineMap} steps.ViewModel.prototype.hasWheelchair hasWheelchair
    * @parent steps.ViewModel
    *
    * for bubble styling when User Avatar has a wheelchair
@@ -58,7 +58,7 @@ export let ViewerStepsVM = DefineMap.extend('ViewerStepsVM', {
   },
 
   /**
-   * @property {can.Map} steps.ViewModel.prototype.currentPage currentPage
+   * @property {DefineMap} steps.ViewModel.prototype.currentPage currentPage
    * @parent steps.ViewModel
    *
    * current page in interview
@@ -77,7 +77,7 @@ export let ViewerStepsVM = DefineMap.extend('ViewerStepsVM', {
   },
 
   /**
-   * @property {can.List} steps.ViewModel.prototype.steps steps
+   * @property {DefineList} steps.ViewModel.prototype.steps steps
    * @parent steps.ViewModel
    *
    * list of steps in the interview
@@ -89,7 +89,7 @@ export let ViewerStepsVM = DefineMap.extend('ViewerStepsVM', {
   },
 
   /**
-   * @property {can.Map} steps.ViewModel.prototype.currentStep currentStep
+   * @property {DefineMap} steps.ViewModel.prototype.currentStep currentStep
    * @parent steps.ViewModel
    *
    * current step in interview
@@ -113,7 +113,7 @@ export let ViewerStepsVM = DefineMap.extend('ViewerStepsVM', {
   },
 
   /**
-   * @property {can.List} steps.ViewModel.prototype.nextSteps nextSteps
+   * @property {DefineList} steps.ViewModel.prototype.nextSteps nextSteps
    * @parent steps.ViewModel
    *
    * list of steps after current step in interview
@@ -235,7 +235,9 @@ export let ViewerStepsVM = DefineMap.extend('ViewerStepsVM', {
    */
   showUserAvatar: {
     get () {
-      return this.interview.attr('avatarGender') && !this.currentPage.hasUserGenderOrAvatarField
+      const hasAvatarGender = !!this.interview.attr('avatarGender')
+      const noGenderFieldInPage = this.currentPage && !this.currentPage.hasUserGenderOrAvatarField
+      return hasAvatarGender && noGenderFieldInPage
     }
   },
 

--- a/src/desktop/steps/steps.js
+++ b/src/desktop/steps/steps.js
@@ -1,5 +1,5 @@
 import $ from 'jquery'
-import CanMap from 'can-map'
+import DefineMap from 'can-define/map/map'
 import _isNaN from 'lodash/isNaN'
 import _inRange from 'lodash/inRange'
 import _some from 'lodash/some'
@@ -12,13 +12,6 @@ import { analytics } from '~/src/util/analytics'
 import stache from 'can-stache'
 import canReflect from 'can-reflect'
 
-import 'can-map-define'
-
-// !steal-remove-start
-import debug from 'can-debug'
-debug()
-// !steal-remove-end
-
 stache.registerPartial('learn-more-tpl', learnMoreTemplate)
 
 /**
@@ -27,354 +20,355 @@ stache.registerPartial('learn-more-tpl', learnMoreTemplate)
  *
  * `<a2j-viewer-steps>`'s viewModel.
  */
-export let ViewerStepsVM = CanMap.extend('ViewerStepsVM', {
-  define: {
-    // passed in via desktop.stache bindings
-    showDebugPanel: {},
-    lang: {},
-    logic: {},
-    appState: {},
-    pState: {},
-    mState: {},
-    interview: {},
-    modalContent: {},
+export let ViewerStepsVM = DefineMap.extend('ViewerStepsVM', {
+  // passed in via desktop.stache bindings
+  appState: {},
+  mState: {},
+  pState: {},
+  showDebugPanel: {},
+  lang: {},
+  logic: {},
+  interview: {},
+  modalContent: {},
+  // passed up from pages-stache
+  traceMessage: {},
 
-    /**
-     * @property {can.DefineMap} steps.ViewModel.prototype.userAvatar userAvatar
-     * @parent steps.ViewModel
-     *
-     * current User Avatar in interview
-     */
-    userAvatar: {
-      get () {
-        return this.attr('appState').userAvatar
-      }
-    },
-
-    /**
-     * @property {can.DefineMap} steps.ViewModel.prototype.hasWheelchair hasWheelchair
-     * @parent steps.ViewModel
-     *
-     * for bubble styling when User Avatar has a wheelchair
-     */
-    hasWheelchair: {
-      get () {
-        return this.attr('userAvatar').hasWheelchair
-      }
-    },
-
-    /**
-     * @property {can.Map} steps.ViewModel.prototype.currentPage currentPage
-     * @parent steps.ViewModel
-     *
-     * current page in interview
-     */
-    currentPage: {
-      get () {
-        return this.attr('appState').currentPage
-      }
-    },
-
-    hasAvatarPicker: {
-      get () {
-        const fields = this.attr('currentPage.fields')
-        return _some(fields, field => field.attr('type') === 'useravatar')
-      }
-    },
-
-    /**
-     * @property {can.List} steps.ViewModel.prototype.steps steps
-     * @parent steps.ViewModel
-     *
-     * list of steps in the interview
-     */
-    steps: {
-      get () {
-        return this.attr('interview.steps')
-      }
-    },
-
-    /**
-     * @property {can.Map} steps.ViewModel.prototype.currentStep currentStep
-     * @parent steps.ViewModel
-     *
-     * current step in interview
-     */
-    currentStep: {
-      get () {
-        return this.attr('currentPage') && this.attr('currentPage.step')
-      }
-    },
-
-    /**
-     * @property {Boolean} steps.ViewModel.prototype.hasStep hasStep
-     * @parent steps.ViewModel
-     *
-     * has a currentStep
-     */
-    hasStep: {
-      type: 'boolean',
-      get () {
-        return !!this.attr('currentStep')
-      }
-    },
-
-    /**
-     * @property {can.List} steps.ViewModel.prototype.nextSteps nextSteps
-     * @parent steps.ViewModel
-     *
-     * list of steps after current step in interview
-     */
-    nextSteps: {
-      get () {
-        const currentStepIndex = this.getStepIndex(this.attr('currentStep'))
-        return this.attr('steps').slice(currentStepIndex + 1)
-      }
-    },
-
-    /**
-     * @property {Number} steps.ViewModel.prototype.remainingSteps remainingSteps
-     * @parent steps.ViewModel
-     *
-     * number of steps after current step in interview
-     */
-    remainingSteps: {
-      get () {
-        return this.attr('nextSteps.length')
-      }
-    },
-
-    /**
-     * @property {Number} steps.ViewModel.prototype.maxDisplayedSteps maxDisplayedSteps
-     * @parent steps.ViewModel
-     *
-     * maximum number of steps to display on screen
-     *
-     * based on the height of the sidewalk and number of steps in the interview
-     *
-     */
-    maxDisplayedSteps: {
-      get () {
-        let sidewalkHeight = this.attr('sidewalkHeight')
-        let interviewSteps = this.attr('steps.length')
-        let maxSteps
-
-        if (sidewalkHeight < 100) {
-          maxSteps = 1
-        } else if (_inRange(sidewalkHeight, 100, 450)) {
-          maxSteps = 2
-        } else if (_inRange(sidewalkHeight, 450, 550)) {
-          maxSteps = 3
-        } else if (_inRange(sidewalkHeight, 550, 750)) {
-          maxSteps = 4
-        } else {
-          maxSteps = 5
-        }
-
-        return interviewSteps < maxSteps ? interviewSteps : maxSteps
-      }
-    },
-
-    /**
-     * @property {Array} steps.ViewModel.prototype.a2jStepVars a2jStepVars
-     * @parent steps.ViewModel
-     *
-     * list of the A2J Step variables and their values
-     * listens for changes to A2J Step variables during an interview - used to update displayText
-     */
-    a2jStepVars: {
-      get () {
-        let a2jStepVars = []
-        let answers = this.attr('interview.answers')
-        if (answers) {
-          canReflect.eachKey(answers, function (answer) {
-            if (answer && answer.name && answer.name.indexOf('A2J Step') !== -1) {
-              answer.attr('values.length') // setup binding on values
-              a2jStepVars.push(answer)
-            }
-          })
-        }
-        return a2jStepVars
-      }
-    },
-
-    /**
-     * @property {String} steps.ViewModel.prototype.guideAvatarSkinTone guideAvatarSkinTone
-     * @parent steps.ViewModel
-     *
-     * skin tone of the guide avatar to be displayed in steps
-     *
-     */
-    guideAvatarSkinTone: {
-      get () {
-        const globalSkinTone = this.attr('mState.avatarSkinTone')
-        const interviewSkinTone = this.attr('interview.avatarSkinTone')
-        return globalSkinTone || interviewSkinTone
-      }
-    },
-
-    /**
-     * @property {String} steps.ViewModel.prototype.guideAvatarHairColor guideAvatarHairColor
-     * @parent steps.ViewModel
-     *
-     * hair color of the guide avatar to be displayed in steps
-     *
-     */
-    guideAvatarHairColor: {
-      get () {
-        const globalHairColor = this.attr('mState.avatarHairColor')
-        const interviewHairColor = this.attr('interview.avatarHairColor')
-        return globalHairColor || interviewHairColor
-      }
-    },
-
-    /**
-     * @property {Number} steps.ViewModel.prototype.showUserAvatar showUserAvatar
-     * @parent steps.ViewModel
-     *
-     * whether the user avatar should be shown
-     *
-     * we should not show the user avatar if the current page has the user
-     * gender field, this prevents the avatar to be rendered right when user
-     * selects their gender, which causes a weird jump of the avatar bubble.
-     *
-     */
-    showUserAvatar: {
-      get () {
-        return this.attr('interview.avatarGender') && !this.attr('currentPage.hasUserGenderOrAvatarField')
-      }
-    },
-
-    /**
-     * @property {Number} steps.ViewModel.prototype.guideAvatarFacingDirection guideAvatarFacingDirection
-     * @parent steps.ViewModel
-     *
-     * direction the guide avatar should face
-     *
-     * face right when user avatar is displayed; otherwise, face front
-     *
-     */
-    guideAvatarFacingDirection: {
-      get () {
-        return this.attr('showUserAvatar') ? 'right' : 'front'
-      }
-    },
-
-    /**
-     * @property {Number} steps.ViewModel.prototype.sidewalkLength sidewalkLength
-     * @parent steps.ViewModel
-     *
-     * length of the angled side of the sidewalk
-     *
-     * this is the hypoteneuse of the right-triangle used for drawing the sidewalk
-     * where the other sides of the triangle are the height and width of the `<div id="sidewalk"></div>`
-     *
-     */
-    sidewalkLength: {
-      type: 'number',
-      get () {
-        let sidewalkHeight = this.attr('sidewalkHeight')
-        let sidewalkWidth = this.attr('sidewalkWidth')
-        return Math.sqrt(Math.pow(sidewalkHeight, 2) + Math.pow(sidewalkWidth, 2))
-      }
-    },
-
-    /**
-     * @property {Number} steps.ViewModel.prototype.sidewalkAngleA sidewalkAngleA
-     * @parent steps.ViewModel
-     *
-     * Angle of bottom left corner of the right-triangle used for drawing the sidewalk
-     * used for approximating the width of each step
-     *
-     * calculated by solving the equation `sin(A) = h1 / w1`
-     *
-     * @codestart
-     *               /|  ______
-     *              / |       |
-     *             /  |       |
-     *            /   |       |
-     *           /    |      h1
-     *          /     |       |
-     *         /      |       |
-     *        /_______|  _____|
-     *       A    w1
-     * @codeend
-     */
-    sidewalkAngleA: {
-      type: 'number',
-      get () {
-        return Math.asin(this.attr('sidewalkHeight') / this.attr('sidewalkLength'))
-      }
-    },
-
-    /**
-     * @property {Number} steps.ViewModel.prototype.guideBubbleTallerThanAvatar guideBubbleTallerThanAvatar
-     * @parent steps.ViewModel
-     *
-     * whether the guide bubble is taller than the avatar
-     * bubbles with useravatar field types are always styled `vertical` (see steps.stache)
-     *
-     */
-    guideBubbleTallerThanAvatar: {
-      get () {
-        return this.attr('hasAvatarPicker') || this.attr('guideBubbleHeight') > this.attr('avatarHeight')
-      }
-    },
-
-    /**
-     * @property {Number} steps.ViewModel.prototype.userBubbleTallerThanAvatar userBubbleTallerThanAvatar
-     * @parent steps.ViewModel
-     *
-     * whether the user bubble is taller than the avatar
-     *
-     */
-    userBubbleTallerThanAvatar: {
-      get () {
-        return this.attr('clientBubbleHeight') > this.attr('avatarHeight')
-      }
-    },
-
-    /**
-     * @property {Number} steps.ViewModel.prototype.minusHeader minusHeader
-     * @parent steps.ViewModel
-     *
-     * @minusHeader less variable reverse engineered
-     *
-     */
-    minusHeader: {
-      type: 'number',
-      get () {
-        let headerHeight = this.attr('bodyHeight') - this.attr('sidewalkHeight')
-        return Math.ceil(headerHeight / 2)
-      }
-    },
-
-    /**
-     * DOM values
-     */
-    bodyHeight: {
-      type: 'number'
-    },
-
-    sidewalkHeight: {
-      type: 'number'
-    },
-
-    sidewalkWidth: {
-      type: 'number'
-    },
-
-    guideBubbleHeight: {
-      type: 'number'
-    },
-
-    avatarHeight: {
-      type: 'number'
-    },
-
-    avatarOffsetTop: {
-      type: 'number'
+  /**
+   * @property {can.DefineMap} steps.ViewModel.prototype.userAvatar userAvatar
+   * @parent steps.ViewModel
+   *
+   * current User Avatar in interview
+   */
+  userAvatar: {
+    get () {
+      return this.appState.userAvatar
     }
+  },
+
+  /**
+   * @property {can.DefineMap} steps.ViewModel.prototype.hasWheelchair hasWheelchair
+   * @parent steps.ViewModel
+   *
+   * for bubble styling when User Avatar has a wheelchair
+   */
+  hasWheelchair: {
+    get () {
+      return this.userAvatar.hasWheelchair
+    }
+  },
+
+  /**
+   * @property {can.Map} steps.ViewModel.prototype.currentPage currentPage
+   * @parent steps.ViewModel
+   *
+   * current page in interview
+   */
+  currentPage: {
+    get () {
+      return this.appState.currentPage
+    }
+  },
+
+  hasAvatarPicker: {
+    get () {
+      const fields = this.currentPage.fields
+      return _some(fields, field => field.type === 'useravatar')
+    }
+  },
+
+  /**
+   * @property {can.List} steps.ViewModel.prototype.steps steps
+   * @parent steps.ViewModel
+   *
+   * list of steps in the interview
+   */
+  steps: {
+    get () {
+      return this.interview.attr('steps')
+    }
+  },
+
+  /**
+   * @property {can.Map} steps.ViewModel.prototype.currentStep currentStep
+   * @parent steps.ViewModel
+   *
+   * current step in interview
+   */
+  currentStep: {
+    get () {
+      return this.currentPage && this.currentPage.step
+    }
+  },
+
+  /**
+   * @property {Boolean} steps.ViewModel.prototype.hasStep hasStep
+   * @parent steps.ViewModel
+   *
+   * has a currentStep
+   */
+  hasStep: {
+    get () {
+      return !!this.currentStep
+    }
+  },
+
+  /**
+   * @property {can.List} steps.ViewModel.prototype.nextSteps nextSteps
+   * @parent steps.ViewModel
+   *
+   * list of steps after current step in interview
+   */
+  nextSteps: {
+    get () {
+      const currentStepIndex = this.getStepIndex(this.currentStep)
+      return this.steps.slice(currentStepIndex + 1)
+    }
+  },
+
+  /**
+   * @property {Number} steps.ViewModel.prototype.remainingSteps remainingSteps
+   * @parent steps.ViewModel
+   *
+   * number of steps after current step in interview
+   */
+  remainingSteps: {
+    get () {
+      return this.nextSteps.length
+    }
+  },
+
+  /**
+   * @property {Number} steps.ViewModel.prototype.maxDisplayedSteps maxDisplayedSteps
+   * @parent steps.ViewModel
+   *
+   * maximum number of steps to display on screen
+   *
+   * based on the height of the sidewalk and number of steps in the interview
+   *
+   */
+  maxDisplayedSteps: {
+    get () {
+      let sidewalkHeight = this.sidewalkHeight
+      let interviewSteps = this.steps.length
+      let maxSteps
+
+      if (sidewalkHeight < 100) {
+        maxSteps = 1
+      } else if (_inRange(sidewalkHeight, 100, 450)) {
+        maxSteps = 2
+      } else if (_inRange(sidewalkHeight, 450, 550)) {
+        maxSteps = 3
+      } else if (_inRange(sidewalkHeight, 550, 750)) {
+        maxSteps = 4
+      } else {
+        maxSteps = 5
+      }
+
+      return interviewSteps < maxSteps ? interviewSteps : maxSteps
+    }
+  },
+
+  /**
+   * @property {Array} steps.ViewModel.prototype.a2jStepVars a2jStepVars
+   * @parent steps.ViewModel
+   *
+   * list of the A2J Step variables and their values
+   * listens for changes to A2J Step variables during an interview - used to update displayText
+   */
+  a2jStepVars: {
+    get () {
+      let a2jStepVars = []
+      let answers = this.interview.attr('answers')
+      if (answers) {
+        canReflect.eachKey(answers, function (answer) {
+          if (answer && answer.name && answer.name.indexOf('A2J Step') !== -1) {
+            // TODO: bind this properly, but setup binding on values
+            const length = answer.values.length // eslint-disable-line
+            a2jStepVars.push(answer)
+          }
+        })
+      }
+      return a2jStepVars
+    }
+  },
+
+  /**
+   * @property {String} steps.ViewModel.prototype.guideAvatarSkinTone guideAvatarSkinTone
+   * @parent steps.ViewModel
+   *
+   * skin tone of the guide avatar to be displayed in steps
+   *
+   */
+  guideAvatarSkinTone: {
+    get () {
+      const globalSkinTone = this.mState.avatarSkinTone
+      const interviewSkinTone = this.interview.attr('avatarSkinTone')
+      return globalSkinTone || interviewSkinTone
+    }
+  },
+
+  /**
+   * @property {String} steps.ViewModel.prototype.guideAvatarHairColor guideAvatarHairColor
+   * @parent steps.ViewModel
+   *
+   * hair color of the guide avatar to be displayed in steps
+   *
+   */
+  guideAvatarHairColor: {
+    get () {
+      const globalHairColor = this.mState.avatarHairColor
+      const interviewHairColor = this.interview.attr('avatarHairColor')
+      return globalHairColor || interviewHairColor
+    }
+  },
+
+  /**
+   * @property {Number} steps.ViewModel.prototype.showUserAvatar showUserAvatar
+   * @parent steps.ViewModel
+   *
+   * whether the user avatar should be shown
+   *
+   * we should not show the user avatar if the current page has the user
+   * gender field, this prevents the avatar to be rendered right when user
+   * selects their gender, which causes a weird jump of the avatar bubble.
+   *
+   */
+  showUserAvatar: {
+    get () {
+      return this.interview.attr('avatarGender') && !this.currentPage.hasUserGenderOrAvatarField
+    }
+  },
+
+  /**
+   * @property {Number} steps.ViewModel.prototype.guideAvatarFacingDirection guideAvatarFacingDirection
+   * @parent steps.ViewModel
+   *
+   * direction the guide avatar should face
+   *
+   * face right when user avatar is displayed; otherwise, face front
+   *
+   */
+  guideAvatarFacingDirection: {
+    get () {
+      return this.showUserAvatar ? 'right' : 'front'
+    }
+  },
+
+  /**
+   * @property {Number} steps.ViewModel.prototype.sidewalkLength sidewalkLength
+   * @parent steps.ViewModel
+   *
+   * length of the angled side of the sidewalk
+   *
+   * this is the hypoteneuse of the right-triangle used for drawing the sidewalk
+   * where the other sides of the triangle are the height and width of the `<div id="sidewalk"></div>`
+   *
+   */
+  sidewalkLength: {
+    get () {
+      let sidewalkHeight = this.sidewalkHeight
+      let sidewalkWidth = this.sidewalkWidth
+      return Math.sqrt(Math.pow(sidewalkHeight, 2) + Math.pow(sidewalkWidth, 2))
+    }
+  },
+
+  /**
+   * @property {Number} steps.ViewModel.prototype.sidewalkAngleA sidewalkAngleA
+   * @parent steps.ViewModel
+   *
+   * Angle of bottom left corner of the right-triangle used for drawing the sidewalk
+   * used for approximating the width of each step
+   *
+   * calculated by solving the equation `sin(A) = h1 / w1`
+   *
+   * @codestart
+   *               /|  ______
+   *              / |       |
+   *             /  |       |
+   *            /   |       |
+   *           /    |      h1
+   *          /     |       |
+   *         /      |       |
+   *        /_______|  _____|
+   *       A    w1
+   * @codeend
+   */
+  sidewalkAngleA: {
+    get () {
+      return Math.asin(this.sidewalkHeight / this.sidewalkLength)
+    }
+  },
+
+  /**
+   * @property {Number} steps.ViewModel.prototype.guideBubbleTallerThanAvatar guideBubbleTallerThanAvatar
+   * @parent steps.ViewModel
+   *
+   * whether the guide bubble is taller than the avatar
+   * bubbles with useravatar field types are always styled `vertical` (see steps.stache)
+   *
+   */
+  guideBubbleTallerThanAvatar: {
+    get () {
+      return this.hasAvatarPicker || this.guideBubbleHeight > this.avatarHeight
+    }
+  },
+
+  /**
+   * @property {Number} steps.ViewModel.prototype.userBubbleTallerThanAvatar userBubbleTallerThanAvatar
+   * @parent steps.ViewModel
+   *
+   * whether the user bubble is taller than the avatar
+   *
+   */
+  userBubbleTallerThanAvatar: {
+    get () {
+      return this.clientBubbleHeight > this.avatarHeight
+    }
+  },
+
+  /**
+   * @property {Number} steps.ViewModel.prototype.minusHeader minusHeader
+   * @parent steps.ViewModel
+   *
+   * @minusHeader less variable reverse engineered
+   *
+   */
+  minusHeader: {
+    get () {
+      let headerHeight = this.bodyHeight - this.sidewalkHeight
+      return Math.ceil(headerHeight / 2)
+    }
+  },
+
+  /**
+   * DOM values
+   */
+  bodyHeight: {
+    type: 'number'
+  },
+
+  sidewalkHeight: {
+    type: 'number'
+  },
+
+  sidewalkWidth: {
+    type: 'number'
+  },
+
+  guideBubbleHeight: {
+    type: 'number'
+  },
+
+  clientBubbleHeight: {
+    type: 'number'
+  },
+
+  avatarHeight: {
+    type: 'number'
+  },
+
+  avatarOffsetTop: {
+    type: 'number'
   },
 
   /**
@@ -384,10 +378,10 @@ export let ViewerStepsVM = CanMap.extend('ViewerStepsVM', {
    * index for a given step, step.number and index do not have to match
    */
   getStepIndex (step) {
-    if (!step) { return }
-    const steps = this.attr('steps').attr()
+    if (!step || !this.steps) { return }
+    const steps = this.steps.attr()
     const stepIndex = _findIndex(steps, ({ number }) => {
-      return number === step.attr('number')
+      return number === step.number
     })
 
     return stepIndex
@@ -402,11 +396,11 @@ export let ViewerStepsVM = CanMap.extend('ViewerStepsVM', {
   getTextForStep (step) {
     if (!step) { return }
     const index = this.getStepIndex(step)
-    const defaultText = this.attr(`interview.steps.${index}.text`)
+    const defaultText = this.interview.attr(`steps.${index}.text`)
     let variableText
-    const variable = this.attr('a2jStepVars')[index]
+    const variable = this.a2jStepVars[index]
     if (variable) {
-      variableText = variable.attr('values.1')
+      variableText = variable.values[1]
     }
     return variableText || defaultText
   },
@@ -452,15 +446,15 @@ export let ViewerStepsVM = CanMap.extend('ViewerStepsVM', {
     // for current step, align the bottom of the step with the bottom of the avatar
     // for next steps, align the bottom of the step with the bottom of its parent (set by css)
     let bottom = isCurrentStep
-      ? this.attr('avatarOffsetTop')
+      ? this.avatarOffsetTop
       : cssBottom
 
     // reverse engineer less equation `calc(~"x% - " minusHeader) = bodyHeight`
     // solve above equation for x, which will be percentBelow
-    let percentBelow = Math.ceil(((bottom + this.attr('minusHeader')) / this.attr('bodyHeight')) * 100)
+    let percentBelow = Math.ceil(((bottom + this.minusHeader) / this.bodyHeight) * 100)
     let percentAbove = (100 - percentBelow) / 100
 
-    return (this.attr('sidewalkHeight') * percentAbove) / Math.tan(this.attr('sidewalkAngleA'))
+    return (this.sidewalkHeight * percentAbove) / Math.tan(this.sidewalkAngleA)
   },
 
   /**
@@ -483,21 +477,21 @@ export let ViewerStepsVM = CanMap.extend('ViewerStepsVM', {
   updateDomProperties () {
     let vm = this
 
-    vm.attr('bodyHeight', $('body').height())
+    vm.bodyHeight = $('body').height()
 
     let $sidewalk = $('#sidewalk')
-    vm.attr('sidewalkWidth', $sidewalk.width())
-    vm.attr('sidewalkHeight', $sidewalk.height())
+    vm.sidewalkWidth = $sidewalk.width()
+    vm.sidewalkHeight = $sidewalk.height()
 
     let $guideBubble = $('#guideBubble')
-    vm.attr('guideBubbleHeight', $guideBubble.height())
+    vm.guideBubbleHeight = $guideBubble.height()
 
     let $clientBubble = $('#clientBubble')
-    vm.attr('clientBubbleHeight', $clientBubble.height())
+    vm.clientBubbleHeight = $clientBubble.height()
 
     let $avatar = $guideBubble.parent()
-    vm.attr('avatarHeight', $avatar.height())
-    vm.attr('avatarOffsetTop', $avatar.offset() && $avatar.offset().top)
+    vm.avatarHeight = $avatar.height()
+    vm.avatarOffsetTop = $avatar.offset() && $avatar.offset().top
 
     $('.step-next').each((i, el) => {
       let $el = $(el)
@@ -526,8 +520,8 @@ export let ViewerStepsVM = CanMap.extend('ViewerStepsVM', {
   },
 
   fireLearnMoreModal () {
-    const pages = this.attr('interview.pages')
-    const pageName = this.attr('appState.page')
+    const pages = this.interview.pages
+    const pageName = this.appState.page
 
     if (pages && pageName) {
       const page = pages.find(pageName)
@@ -537,7 +531,7 @@ export let ViewerStepsVM = CanMap.extend('ViewerStepsVM', {
         analytics.trackCustomEvent('Learn-More', 'from: ' + pageName, page.learn)
       }
 
-      this.attr('modalContent', {
+      this.modalContent = {
         // name undefined prevents stache warnings
         answerName: undefined,
         title: page.learn,
@@ -548,7 +542,7 @@ export let ViewerStepsVM = CanMap.extend('ViewerStepsVM', {
         audioURL: page.helpAudioURL,
         videoURL: page.helpVideoURL,
         helpReader: page.helpReader
-      })
+      }
     }
   },
 
@@ -556,11 +550,11 @@ export let ViewerStepsVM = CanMap.extend('ViewerStepsVM', {
     const vm = this
     const restoreUserAvatar = (ev, show) => {
       if (show) {
-        const answers = vm.attr('interview.answers')
-        const userAvatar = answers.attr('user avatar')
-        const previousUserAvatar = userAvatar.attr('values.1')
+        const answers = vm.interview.answers
+        const userAvatar = answers['user avatar']
+        const previousUserAvatar = userAvatar.values[1]
         if (previousUserAvatar) {
-          vm.attr('appState').userAvatar.update(JSON.parse(previousUserAvatar))
+          vm.appState.userAvatar.update(JSON.parse(previousUserAvatar))
         }
       }
     }

--- a/src/desktop/steps/steps.stache
+++ b/src/desktop/steps/steps.stache
@@ -23,8 +23,7 @@
             pState:from="pState"
             mState:from="mState"
             interview:from="interview"
-            traceMessage:to="traceMessage"
-            modalContent:bind="modalContent" />
+            traceMessage:to="traceMessage" />
       </div><!-- guideBubble -->
 
       {{#not(showUserAvatar)}}

--- a/src/desktop/steps/steps.stache
+++ b/src/desktop/steps/steps.stache
@@ -19,7 +19,7 @@
             resumeInterview:from="resumeInterview"
             lang:from="lang"
             logic:from="logic"
-            rState:from="rState"
+            appState:from="appState"
             pState:from="pState"
             mState:from="mState"
             interview:from="interview"

--- a/src/footer/footer-test.html
+++ b/src/footer/footer-test.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Viewer Footer Tests</title>
+  </head>
+
+  <body>
+    <div id="mocha"></div>
+    <div id="test-area"></div>
+
+    <script src="../../node_modules/steal/steal.js"
+      data-mocha="bdd"
+      data-main="~/src/footer/footer-test"></script>
+  </body>
+</html>

--- a/src/footer/footer-test.js
+++ b/src/footer/footer-test.js
@@ -1,0 +1,17 @@
+import { assert } from 'chai'
+import 'steal-mocha'
+
+import { FooterVM } from '~/src/footer/'
+/* global describe it beforeEach afterEach */
+
+describe('<a2j-viewer-steps>', function () {
+  let vm
+  beforeEach(() => {
+    vm = new FooterVM()
+  })
+  describe('ViewModel', function () {
+    it('viewerVersion', () => {
+      assert.equal(typeof vm.viewerVersion, 'string', 'should create the viewerVersion')
+    })
+  })
+})

--- a/src/footer/footer.js
+++ b/src/footer/footer.js
@@ -21,7 +21,7 @@ let FooterVM = CanMap.extend({
     // Used to hide status updates in Author preview mode
     showCAJAStatus: {
       get () {
-        return !this.attr('rState.previewActive')
+        return !this.attr('appState.previewActive')
       }
     }
   }

--- a/src/footer/footer.js
+++ b/src/footer/footer.js
@@ -1,30 +1,32 @@
 import Component from 'can-component'
 import template from './footer.stache'
-import CanMap from 'can-map'
+import DefineMap from 'can-define/map/map'
 import constants from '~/src/models/constants'
 import moment from 'moment'
 
 import 'can-map-define'
 
-let FooterVM = CanMap.extend({
-  define: {
-    viewerVersion: {
-      get () {
-        return 'A2J ' + constants.A2JVersionNum + '-' + constants.A2JVersionDate
-      }
-    },
-    currentYear: {
-      get () {
-        return moment().year()
-      }
-    },
-    // Used to hide status updates in Author preview mode
-    showCAJAStatus: {
-      get () {
-        return !this.attr('appState.previewActive')
-      }
+export const FooterVM = DefineMap.extend('FooterVM', {
+  // passed in from desktop.stache
+  appState: {},
+
+  viewerVersion: {
+    get () {
+      return 'A2J ' + constants.A2JVersionNum + '-' + constants.A2JVersionDate
+    }
+  },
+  currentYear: {
+    get () {
+      return moment().year()
+    }
+  },
+  // Used to hide status updates in Author preview mode
+  showCAJAStatus: {
+    get () {
+      return !this.appState.previewActive
     }
   }
+
 })
 
 export default Component.extend({

--- a/src/mobile/header/footer-test.js
+++ b/src/mobile/header/footer-test.js
@@ -1,0 +1,17 @@
+import { assert } from 'chai'
+import 'steal-mocha'
+
+import { FooterVM } from '~/src/footer/'
+/* global describe it beforeEach afterEach */
+
+describe('<a2j-viewer-steps>', function () {
+  let vm
+  beforeEach(() => {
+    vm = new FooterVM()
+  })
+  describe('ViewModel', function () {
+    it('viewerVersion', () => {
+      assert.equal(typeof vm.viewerVersion, 'string', 'should create the viewerVersion')
+    })
+  })
+})

--- a/src/mobile/header/header-test.html
+++ b/src/mobile/header/header-test.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Viewer Header Tests</title>
+  </head>
+
+  <body>
+    <div id="mocha"></div>
+    <div id="test-area"></div>
+
+    <script src="../../../node_modules/steal/steal.js"
+      data-mocha="bdd"
+      data-main="~/src/mobile/header/header-test"></script>
+  </body>
+</html>

--- a/src/mobile/header/header-test.js
+++ b/src/mobile/header/header-test.js
@@ -14,12 +14,13 @@ describe('a2j-header', function () {
   beforeEach(function () {
     const mState = new CanMap()
     const pState = new CanMap()
+    const interview = new CanMap({ title: 'Awesome GI' })
 
     const frag = stache(
-      '<a2j-header vm:mState:from="mState" vm:pState:from="pState" />'
+      '<a2j-header mState:from="mState" pState:from="pState" interview:from="interview" />'
     )
 
-    $('#test-area').html(frag({ mState, pState }))
+    $('#test-area').html(frag({ mState, pState, interview }))
     vm = $('a2j-header')[0].viewModel
   })
 
@@ -28,13 +29,13 @@ describe('a2j-header', function () {
   })
 
   it('shows save button if autoSetDataURL is set', function () {
-    vm.attr('mState.autoSetDataURL', '/ajax-save.php')
-    assert.equal(vm.attr('mState.autoSetDataURL'), '/ajax-save.php')
+    vm.mState.attr('autoSetDataURL', '/ajax-save.php')
+    assert.equal(vm.mState.attr('autoSetDataURL'), '/ajax-save.php')
     assert($('.btn.save').is(':visible'), 'save button should be visible')
   })
 
   it('does not show save button if autoSetDataURL not set', function () {
-    assert.isUndefined(vm.attr('mState.autoSetDataURL'))
+    assert.isUndefined(vm.mState.attr('autoSetDataURL'))
     assert(!$('.btn.save').length, 'save button should not be in the DOM')
   })
 
@@ -43,7 +44,7 @@ describe('a2j-header', function () {
     const button = '.btn.save'
     const deferred = $.Deferred()
     setupPromise(deferred)
-    const pState = vm.attr('pState')
+    const pState = vm.pState
 
     // mock the save method
     pState.save = () => {
@@ -52,7 +53,7 @@ describe('a2j-header', function () {
     }
 
     // show save button
-    vm.attr('mState.autoSetDataURL', '/ajax-save.php')
+    vm.mState.attr('autoSetDataURL', '/ajax-save.php')
 
     F(button).visible(true)
     F(button).click()
@@ -77,7 +78,7 @@ describe('a2j-header', function () {
     const button = '.btn.save'
     const deferred = $.Deferred()
     setupPromise(deferred)
-    const pState = vm.attr('pState')
+    const pState = vm.pState
 
     // mock the save method
     pState.save = () => {
@@ -86,7 +87,7 @@ describe('a2j-header', function () {
     }
 
     // show save button
-    vm.attr('mState.autoSetDataURL', '/ajax-save.php')
+    vm.mState.attr('autoSetDataURL', '/ajax-save.php')
 
     F(button).visible(true)
     F(button).click()

--- a/src/mobile/header/header-test.js
+++ b/src/mobile/header/header-test.js
@@ -39,7 +39,7 @@ describe('a2j-header', function () {
     assert(!$('.btn.save').length, 'save button should not be in the DOM')
   })
 
-  it('save button is disabled while ajax is pending and succeds', function (done) {
+  it('save button is disabled while ajax is pending and succeeds', function (done) {
     let called = false
     const button = '.btn.save'
     const deferred = $.Deferred()

--- a/src/mobile/header/header.js
+++ b/src/mobile/header/header.js
@@ -1,8 +1,6 @@
-import CanMap from 'can-map'
+import DefineMap from 'can-define/map/map'
 import Component from 'can-component'
 import template from './header.stache'
-
-import 'can-map-define'
 
 /**
  * @module {Module} viewer/mobile/header/ <a2j-header>
@@ -13,7 +11,7 @@ import 'can-map-define'
  * ## Use
  *
  * @codestart
- *   <a2j-header {m-state}="mState" {p-state}="pState" />
+ *   <a2j-header pState:from="pState" mState:from="mState" interview:from="interview" />
  * @codeend
  */
 
@@ -23,41 +21,43 @@ import 'can-map-define'
  *
  * `<a2j-header>` viewModel.
  */
-const HeaderVM = CanMap.extend({
-  define: {
-    /**
-     * @property {Booelan} header.ViewModel.prototype.disableSaveButton disableSaveButton
-     * @parent conditional.ViewModel
-     *
-     * Whether the save button should be disabled or not.
-     */
-    disableSaveButton: {
-      value: false
-    },
+const HeaderVM = DefineMap.extend({
+  // passed in from mobile.stache
+  pState: {},
+  mState: {},
+  interview: {},
+  /**
+   * @property {Booelan} header.ViewModel.prototype.disableSaveButton disableSaveButton
+   * @parent conditional.ViewModel
+   *
+   * Whether the save button should be disabled or not.
+   */
+  disableSaveButton: {
+    default: false
+  },
 
-    /**
-     * @property {Booelan} header.ViewModel.prototype.showSaveButton showSaveButton
-     * @parent conditional.ViewModel
-     *
-     * Whether the display the save button.
-     */
-    showSaveButton: {
-      get () {
-        return !!this.attr('mState.autoSetDataURL')
-      }
+  /**
+   * @property {Booelan} header.ViewModel.prototype.showSaveButton showSaveButton
+   * @parent conditional.ViewModel
+   *
+   * Whether the display the save button.
+   */
+  showSaveButton: {
+    get () {
+      return !!this.mState.attr('autoSetDataURL')
     }
   },
 
   toggleCredits () {
-    const currentVal = this.attr('mState.showCredits')
-    this.attr('mState.showCredits', !currentVal)
+    const currentVal = this.mState.attr('showCredits')
+    this.mState.showCredits = !currentVal
   },
 
   save () {
-    this.attr('disableSaveButton', true)
+    this.disableSaveButton = true
 
-    this.attr('pState').save().always(() => {
-      this.attr('disableSaveButton', false)
+    this.pState.save().always(() => {
+      this.disableSaveButton = false
     })
   }
 })

--- a/src/mobile/mobile.js
+++ b/src/mobile/mobile.js
@@ -12,7 +12,11 @@ const MobileViewerVM = CanMap.extend('MobileViewerVM', {
     pState: {},
     mState: {},
     interview: {},
-    modalContent: {}
+    modalContent: {
+      get () {
+        return this.appState.modalContent
+      }
+    }
   },
   hideCredits: function () {
     this.attr('mState.showCredits', false)

--- a/src/mobile/mobile.js
+++ b/src/mobile/mobile.js
@@ -8,7 +8,7 @@ const MobileViewerVM = CanMap.extend('MobileViewerVM', {
     // passed in via app.stache bindings
     lang: {},
     logic: {},
-    rState: {},
+    appState: {},
     pState: {},
     mState: {},
     interview: {},

--- a/src/mobile/mobile.js
+++ b/src/mobile/mobile.js
@@ -1,34 +1,31 @@
-import CanMap from 'can-map'
+import DefineMap from 'can-define/map/map'
 import Component from 'can-component'
 import template from './mobile.stache'
-import 'can-map-define'
 
-const MobileViewerVM = CanMap.extend('MobileViewerVM', {
-  define: {
-    // passed in via app.stache bindings
-    lang: {},
-    logic: {},
-    appState: {},
-    pState: {},
-    mState: {},
-    interview: {},
-    modalContent: {
-      get () {
-        return this.appState.modalContent
-      }
+const MobileViewerVM = DefineMap.extend('MobileViewerVM', {
+  // passed in via app.stache bindings
+  lang: {},
+  logic: {},
+  appState: {},
+  pState: {},
+  mState: {},
+  interview: {},
+  modalContent: {
+    get () {
+      return this.appState.modalContent
     }
   },
+
   hideCredits: function () {
-    this.attr('mState.showCredits', false)
+    this.mState.attr('showCredits', false)
   },
   connectedCallback () {
     // mobile view does not use header or step
-    this.attr('mState.header', '')
-    this.attr('mState.step', '')
+    this.mState.attr('header', '')
+    this.mState.attr('step', '')
   }
 })
 
-// ScreenManager is to handle which view is currently on the screen. Also,
 // if we add any animations on bringing views into the viewport, we'll add that here.
 export default Component.extend({
   view: template,
@@ -38,8 +35,8 @@ export default Component.extend({
 
   helpers: {
     tocOrCreditsShown: function () {
-      const showToc = this.attr('mState.showToc')
-      const showCredits = this.attr('mState.showCredits')
+      const showToc = this.mState.attr('showToc')
+      const showCredits = this.mState.attr('showCredits')
 
       return (showCredits || showToc)
     }

--- a/src/mobile/mobile.stache
+++ b/src/mobile/mobile.stache
@@ -23,29 +23,29 @@
   {{/if}}
 
   {{#not(tocOrCreditsShown())}}
-    {{#eq(rState.view, 'complete')}}
+    {{#eq(appState.view, 'complete')}}
       <img src="{{joinBase 'images/logo_big.png'}}" class="img-responsive" alt="author-logo-image"/>
       <div class="btn-group btn-group-justified">
         <a href="{{mState.redirect}}" aria-label="{{lang.Continue}}" class="btn btn-primary" aui-action="next">{{lang.Continue}}</a>
       </div>
     {{/eq}}
 
-    {{#eq(rState.view, 'pages')}}
+    {{#eq(appState.view, 'pages')}}
       <a2j-viewer-navigation
-        repeatVarValue:from="rState.repeatVarValue"
-        selectedPageName:from="rState.selectedPageName"
+        repeatVarValue:from="appState.repeatVarValue"
+        selectedPageName:from="appState.selectedPageName"
         lang:from="lang"
         logic:from="logic"
-        rState:from="rState"
+        appState:from="appState"
         interview:from="interview"
-        selectedPageName:bind="rState.page"
-        selectedPageIndex:bind="rState.selectedPageIndex" />
+        selectedPageName:bind="appState.page"
+        selectedPageIndex:bind="appState.selectedPageIndex" />
 
       <a2j-pages
-        currentPage:from="rState.currentPage"
+        currentPage:from="appState.currentPage"
         lang:from="lang"
         logic:from="logic"
-        rState:from="rState"
+        appState:from="appState"
         pState:from="pState"
         mState:from="mState"
         interview:from="interview"

--- a/src/mobile/mobile.stache
+++ b/src/mobile/mobile.stache
@@ -48,8 +48,7 @@
         appState:from="appState"
         pState:from="pState"
         mState:from="mState"
-        interview:from="interview"
-        modalContent:bind="modalContent" />
+        interview:from="interview" />
     {{/eq}}
   {{/not}}
 </div>

--- a/src/mobile/pages/fields/field/field-test.js
+++ b/src/mobile/pages/fields/field/field-test.js
@@ -29,7 +29,7 @@ describe('<a2j-field>', () => {
 
       vm = new FieldVM({
         field: fieldStub,
-        rState: {
+        appState: {
           traceMessage: new TraceMessage({
             currentPageName: 'FieldTest'
           }),
@@ -47,7 +47,7 @@ describe('<a2j-field>', () => {
     it('restoreUserAvatar', () => {
       const userAvatarJSON = '{"gender":"male","isOld":true,"hasWheelchair":false,"hairColor":"grayLight","skinTone":"darker"}'
       vm.restoreUserAvatar(userAvatarJSON)
-      const userAvatar = vm.attr('rState.userAvatar')
+      const userAvatar = vm.attr('appState.userAvatar')
       assert.equal(userAvatar.hairColor, 'grayLight', 'should restore userAvatar.hairColor')
       assert.equal(userAvatar.skinTone, 'darker', 'should restore userAvatar.skinTone')
       assert.equal(userAvatar.gender, 'male', 'should restore userAvatar.skinTone')
@@ -251,7 +251,7 @@ describe('<a2j-field>', () => {
         lang: langStub,
         groupValidationMap: new CanMap(),
         lastIndexMap: new CanMap(),
-        rState: {
+        appState: {
           traceMessage: new TraceMessage({
             currentPageName: 'FieldTest'
           }),
@@ -279,7 +279,7 @@ describe('<a2j-field>', () => {
           repeatVarValue:from="repeatVarValue"
           lastIndexMap:from="lastIndexMap"
           groupValidationMap:from="groupValidationMap"
-          rState:from="rState"
+          appState:from="appState"
         />`
       )
 

--- a/src/mobile/pages/fields/field/field-test.js
+++ b/src/mobile/pages/fields/field/field-test.js
@@ -3,8 +3,11 @@ import stache from 'can-stache'
 import { assert } from 'chai'
 import { FieldVM } from './field'
 import AnswerVM from '~/src/models/answervm'
+import AppState from '~/src/models/app-state'
+import Interview from '~/src/models/interview'
 import FieldModel from '~/src/models/field'
-import CanMap from 'can-map'
+import Lang from '~/src/mobile/util/lang'
+import DefineMap from 'can-define/map/map'
 import TraceMessage from '@caliorg/a2jdeps/models/trace-message'
 import sinon from 'sinon'
 
@@ -13,30 +16,34 @@ import 'steal-mocha'
 describe('<a2j-field>', () => {
   describe('viewModel', () => {
     let vm
-    let fieldStub
-
+    let fieldModel
+    const appState = new AppState({
+      traceMessage: new TraceMessage({
+        currentPageName: 'FieldTest'
+      }),
+      interview: new Interview()
+    })
+    const lang = new Lang()
     beforeEach(() => {
-      fieldStub = {
+      fieldModel = new FieldModel({
         name: 'Foo Input',
-        type: '',
-        _answerVm: {
-          answerIndex: 1,
-          answer: {
-            values: [null]
-          }
+        type: ''
+      })
+
+      fieldModel._answerVm = new AnswerVM({
+        answerIndex: 1,
+        field: fieldModel,
+        answer: {
+          values: [null]
         }
-      }
+      })
 
       vm = new FieldVM({
-        field: fieldStub,
-        appState: {
-          traceMessage: new TraceMessage({
-            currentPageName: 'FieldTest'
-          }),
-          userAvatar: {}
-        },
-        groupValidationMap: new CanMap(),
-        lastIndexMap: new CanMap()
+        appState,
+        lang,
+        field: fieldModel,
+        groupValidationMap: new DefineMap(),
+        lastIndexMap: new DefineMap()
       })
     })
 
@@ -47,7 +54,7 @@ describe('<a2j-field>', () => {
     it('restoreUserAvatar', () => {
       const userAvatarJSON = '{"gender":"male","isOld":true,"hasWheelchair":false,"hairColor":"grayLight","skinTone":"darker"}'
       vm.restoreUserAvatar(userAvatarJSON)
-      const userAvatar = vm.attr('appState.userAvatar')
+      const userAvatar = vm.appState.userAvatar
       assert.equal(userAvatar.hairColor, 'grayLight', 'should restore userAvatar.hairColor')
       assert.equal(userAvatar.skinTone, 'darker', 'should restore userAvatar.skinTone')
       assert.equal(userAvatar.gender, 'male', 'should restore userAvatar.skinTone')
@@ -56,30 +63,30 @@ describe('<a2j-field>', () => {
     })
 
     it('should suggest a format for SSN numbers', () => {
-      vm.attr('field').attr('type', 'numberssn')
+      vm.field.type = 'numberssn'
 
-      assert.equal(vm.attr('suggestionText'), '999-99-9999', 'should return ssn format suggestion')
+      assert.equal(vm.suggestionText, '999-99-9999', 'should return ssn format suggestion')
     })
 
     it('should suggest a format for Phone numbers', () => {
-      vm.attr('field').attr('type', 'numberphone')
+      vm.field.type = 'numberphone'
 
-      assert.equal(vm.attr('suggestionText'), '(555) 555-5555', 'should return phone number format suggestion')
+      assert.equal(vm.suggestionText, '(555) 555-5555', 'should return phone number format suggestion')
     })
 
     it('computes numberPickOptions from field min/max values', function () {
-      vm.attr('field').attr({ min: '1', max: '5' })
+      vm.field.assign({ min: '1', max: '5' })
 
       assert.deepEqual(
-        vm.attr('numberPickOptions').serialize(),
+        vm.numberPickOptions.serialize(),
         [1, 2, 3, 4, 5],
         'should return a range including end value'
       )
 
       // if min or max are not valid integers
-      vm.attr('field').attr({ min: '', max: '' })
+      vm.field.assign({ min: '', max: '' })
       assert.deepEqual(
-        vm.attr('numberPickOptions').serialize(),
+        vm.numberPickOptions.serialize(),
         [],
         'should return an empty list'
       )
@@ -109,108 +116,102 @@ describe('<a2j-field>', () => {
     })
 
     it('invalidPrompt', () => {
-      /* jshint ignore:start */
-      vm.attr('lang', {
-        FieldPrompts_checkbox: 'You must select one or more checkboxes to continue.',
-        FieldPrompts_text: 'You must type a response in the highlighted space before you can continue.'
-      })
-      /* jshint ignore:end */
-      vm.attr('field', {name: 'foo'})
-      vm.attr('lastIndexMap', {'foo': 0})
-      vm.attr('fieldIndex', 0)
+      vm.field = {name: 'foo'}
+      vm.lastIndexMap = {'foo': 0}
+      vm.fieldIndex = 0
 
-      vm.attr('groupValidationMap', {'foo': false})
-      assert.ok(!vm.attr('showInvalidPrompt'), 'showInvalidPrompt should be false when there is no error')
+      vm.groupValidationMap = {'foo': false}
+      assert.ok(!vm.showInvalidPrompt, 'showInvalidPrompt should be false when there is no error')
 
-      vm.attr('groupValidationMap', {'foo': true})
-      assert.ok(!vm.attr('showInvalidPrompt'), 'showInvalidPrompt should be false when there is an error but no message')
+      vm.groupValidationMap = {'foo': true}
+      assert.ok(!vm.showInvalidPrompt, 'showInvalidPrompt should be false when there is an error but no message')
 
-      vm.attr('groupValidationMap', {'foo': true})
-      vm.attr('field.type', 'checkbox')
-      vm.removeAttr('field.invalidPrompt')
-      assert.equal(vm.attr('invalidPrompt'), vm.attr('lang.FieldPrompts_checkbox'), 'checkbox - should show the default error message')
+      vm.groupValidationMap = {'foo': true}
+      vm.field.type = 'checkbox'
+      vm.field.invalidPrompt = ''
+      assert.equal(vm.invalidPrompt, vm.lang.FieldPrompts_checkbox, 'checkbox - should show the default error message')
 
-      assert.ok(vm.attr('showInvalidPrompt'), 'checkbox - showInvalidPrompt should be true when there is an error and a default message')
+      assert.ok(vm.showInvalidPrompt, 'checkbox - showInvalidPrompt should be true when there is an error and a default message')
 
-      vm.attr('field.invalidPrompt', 'This is invalid')
-      assert.equal(vm.attr('invalidPrompt'), 'This is invalid', 'checkbox - should show the custom error message')
-      assert.ok(vm.attr('showInvalidPrompt'), 'checkbox - showInvalidPrompt should be true when there is an error and a default message')
+      vm.field.invalidPrompt = 'This is invalid'
+      assert.equal(vm.invalidPrompt, 'This is invalid', 'checkbox - should show the custom error message')
+      assert.ok(vm.showInvalidPrompt, 'checkbox - showInvalidPrompt should be true when there is an error and a default message')
 
-      vm.attr('field.type', 'text')
-      vm.removeAttr('field.invalidPrompt')
-      assert.equal(vm.attr('invalidPrompt'), vm.attr('lang.FieldPrompts_text'), 'text - should show the default error message')
-      assert.ok(vm.attr('showInvalidPrompt'), 'text - showInvalidPrompt should be true when there is an error and a default message')
+      vm.field.type = 'text'
+      vm.field.invalidPrompt = ''
+      assert.equal(vm.invalidPrompt, vm.lang.FieldPrompts_text, 'text - should show the default error message')
+      assert.ok(vm.showInvalidPrompt, 'text - showInvalidPrompt should be true when there is an error and a default message')
 
-      vm.attr('field.invalidPrompt', 'This is invalid')
-      assert.equal(vm.attr('invalidPrompt'), 'This is invalid', 'text - should show the custom error message')
-      assert.ok(vm.attr('showInvalidPrompt'), 'should be true when there is an error and a default message')
-      assert.ok(vm.attr('showInvalidPrompt'), 'text - showInvalidPrompt should be true when there is an error and a default message')
+      vm.field.invalidPrompt = 'This is invalid'
+      assert.equal(vm.invalidPrompt, 'This is invalid', 'text - should show the custom error message')
+      assert.ok(vm.showInvalidPrompt, 'should be true when there is an error and a default message')
+      assert.ok(vm.showInvalidPrompt, 'text - showInvalidPrompt should be true when there is an error and a default message')
     })
 
     it('minMaxPrompt should show or hide based on showMinMaxPrompt', function () {
-      const field = vm.attr('field')
+      const field = vm.field
 
-      field.attr({ 'type': 'number', 'min': null, 'max': null })
-      assert.equal(vm.attr('showMinMaxPrompt'), false, 'if neither min/max has been set, showMinMaxPrompt should be false')
+      field.assign({ 'type': 'number', 'min': null, 'max': null })
+      assert.equal(vm.showMinMaxPrompt, false, 'if neither min/max has been set, showMinMaxPrompt should be false')
 
-      field.attr('min', 5)
-      assert.equal(vm.attr('showMinMaxPrompt'), true, 'if min exists, showMinMaxPrompt should be true')
+      field.min = 5
+      assert.equal(vm.showMinMaxPrompt, true, 'if min exists, showMinMaxPrompt should be true')
 
-      field.attr({ 'min': null, 'max': 15 })
-      assert.equal(vm.attr('showMinMaxPrompt'), true, 'if max exists, showMinMaxPrompt should be true')
+      field.assign({ 'min': null, 'max': 15 })
+      assert.equal(vm.showMinMaxPrompt, true, 'if max exists, showMinMaxPrompt should be true')
     })
 
     it('minMaxPrompt should show min and max values in range display', function () {
-      const field = vm.attr('field')
-      field.attr({ 'type': 'number', 'min': 5, 'max': 15 })
-      assert.equal(vm.attr('minMaxPrompt'), '(5 ~~~ 15)', 'should show the range of acceptable values')
+      const field = vm.field
+      field.assign({ 'type': 'number', 'min': 5, 'max': 15 })
+      assert.equal(vm.minMaxPrompt, '(5 ~~~ 15)', 'should show the range of acceptable values')
 
-      field.attr('min', null)
-      assert.equal(vm.attr('minMaxPrompt'), '(any ~~~ 15)', 'should show the word "any" if min or max value not set')
+      field.min = null
+      assert.equal(vm.minMaxPrompt, '(any ~~~ 15)', 'should show the word "any" if min or max value not set')
     })
 
     it('calcAvailableLength', function () {
       let ev = { target: { value: 'this is' } }
-      let field = vm.attr('field')
-      field.attr({ 'type': 'text', 'maxChars': undefined })
+      let field = vm.field
+      field.assign({ 'type': 'text', 'maxChars': undefined })
 
       vm.calcAvailableLength(ev)
-      assert.equal(vm.attr('availableLength'), null, 'did not return undefined when maxChar not set')
+      assert.equal(vm.availableLength, null, 'did not return undefined when maxChar not set')
 
-      field.attr('maxChars', 10)
+      field.maxChars = 10
       vm.calcAvailableLength(ev)
 
-      assert.equal(vm.attr('availableLength'), 3, 'did not compute remaining characters')
+      assert.equal(vm.availableLength, 3, 'did not compute remaining characters')
     })
 
     it('should detect when maxChar value is overCharacterLimit', function () {
       let ev = { target: { value: 'this is over the limit' } }
-      let field = vm.attr('field')
-      field.attr({
+      let field = vm.field
+      field.assign({
         'type': 'text',
         'maxChars': 10
       })
       vm.calcAvailableLength(ev)
 
-      assert.equal(vm.attr('overCharacterLimit'), true, 'did not detect exceeding answer limit')
+      assert.equal(vm.overCharacterLimit, true, 'did not detect exceeding answer limit')
     })
 
     it('passes textlong answer to modal', function () {
-      const field = vm.attr('field')
-      field.attr('_answerVm.values', 'cash money')
-      field.attr({
+      const field = vm.field
+      field.assign({
         'type': 'textlong',
         'label': 'BigText'
       })
+      field._answerVm.values = 'cash money'
 
       vm.expandTextlong(field)
-      const textlongValue = vm.attr('modalContent.textlongValue')
+      const textlongValue = vm.modalContent.textlongValue
       assert.equal(textlongValue, 'cash money', 'should copy field answer value to modal')
     })
 
     it('date validation normalizes the input value', () => {
-      const field = vm.attr('field')
-      field.attr({ type: 'datemdy', label: 'enter birthday' })
+      const field = vm.field
+      field.assign({ type: 'datemdy', label: 'enter birthday' })
       const input = document.createElement('input')
       input.value = '040120'
       vm.validateField(null, input)
@@ -223,13 +224,12 @@ describe('<a2j-field>', () => {
     let defaults
     let logicStub
     let checkboxVm, notaVm, textVm, numberDollarVm, textpickVm
-    let langStub = new CanMap({
-      MonthNamesShort: 'Jan, Feb',
-      MonthNamesLong: 'January, February'
-    })
+
+    // stub app-state parseText helper
+    stache.registerHelper('parseText', (text) => text)
 
     beforeEach(() => {
-      logicStub = new CanMap({
+      logicStub = new DefineMap({
         exec: $.noop,
         infinite: {
           errors: $.noop,
@@ -247,10 +247,9 @@ describe('<a2j-field>', () => {
       defaults = {
         field: null,
         logic: logicStub,
-        repeatVarValue: '',
-        lang: langStub,
-        groupValidationMap: new CanMap(),
-        lastIndexMap: new CanMap(),
+        lang: new Lang(),
+        groupValidationMap: new DefineMap(),
+        lastIndexMap: new DefineMap(),
         appState: {
           traceMessage: new TraceMessage({
             currentPageName: 'FieldTest'
@@ -268,7 +267,7 @@ describe('<a2j-field>', () => {
       ]
 
       fieldModels.forEach((fieldModel) => {
-        fieldModel.attr('_answerVm', new AnswerVM({ field: fieldModel, answer: fieldModel.emptyAnswer, fields: fieldModels }))
+        fieldModel._answerVm = new AnswerVM({ field: fieldModel, answer: fieldModel.emptyAnswer, fields: fieldModels })
       })
 
       let fieldRenderer = stache(
@@ -276,7 +275,6 @@ describe('<a2j-field>', () => {
           field:from="field"
           lang:from="lang"
           logic:from="logic"
-          repeatVarValue:from="repeatVarValue"
           lastIndexMap:from="lastIndexMap"
           groupValidationMap:from="groupValidationMap"
           appState:from="appState"
@@ -285,19 +283,19 @@ describe('<a2j-field>', () => {
 
       // setup VMs with unique fields
       checkboxVm = new FieldVM(defaults)
-      checkboxVm.attr('field', fieldModels[0])
+      checkboxVm.field = fieldModels[0]
 
       notaVm = new FieldVM(defaults)
-      notaVm.attr('field', fieldModels[1])
+      notaVm.field = fieldModels[1]
 
       textVm = new FieldVM(defaults)
-      textVm.attr('field', fieldModels[2])
+      textVm.field = fieldModels[2]
 
       numberDollarVm = new FieldVM(defaults)
-      numberDollarVm.attr('field', fieldModels[3])
+      numberDollarVm.field = fieldModels[3]
 
       textpickVm = new FieldVM(defaults)
-      textpickVm.attr('field', fieldModels[4])
+      textpickVm.field = fieldModels[4]
 
       $('#test-area').append(fieldRenderer(checkboxVm))
         .append(fieldRenderer(notaVm))
@@ -312,29 +310,29 @@ describe('<a2j-field>', () => {
 
     describe('a2j-field input change', () => {
       it('should set other checkbox values to false when None of the Above is checked', () => {
-        const checkbox = checkboxVm.attr('field')
-        checkbox.attr('_answerVm.answer.values.1', true)
+        const checkbox = checkboxVm.field
+        checkbox._answerVm.answer.values[1] = true
 
         document.getElementById('None of the Above').click()
-        assert.equal(checkbox.attr('_answerVm.values'), false, 'Checking NOTA clears other checkboxes')
+        assert.equal(checkbox._answerVm.values, false, 'Checking NOTA clears other checkboxes')
       })
 
       it('should set checkboxNOTA value to false when another checkbox is checked', () => {
-        const checkboxNOTA = notaVm.attr('field')
-        checkboxNOTA.attr('_answerVm.answer.values.1', true)
+        const checkboxNOTA = notaVm.field
+        checkboxNOTA._answerVm.answer.values[1] = true
 
         document.getElementById('Likes Chocolate TF').click()
-        assert.equal(checkboxNOTA.attr('_answerVm.values'), false, 'Checking NOTA clears other checkboxes')
+        assert.equal(checkboxNOTA._answerVm.values, false, 'Checking NOTA clears other checkboxes')
       })
 
       it('should not affect non checkbox values', () => {
-        let checkbox = checkboxVm.attr('field')
-        checkbox.attr('_answerVm.answer.values.1', false)
-        let textField = textVm.attr('field')
-        textField.attr('_answerVm.answer.values.1', 'Wilhelmina')
+        let checkbox = checkboxVm.field
+        checkbox._answerVm.answer.values[1] = false
+        let textField = textVm.field
+        textField._answerVm.answer.values[1] = 'Wilhelmina'
 
         document.getElementById('Likes Chocolate TF').click()
-        assert.equal(textField.attr('_answerVm.answer.values.1'), 'Wilhelmina', 'Checking checkbox does not change text field')
+        assert.equal(textField._answerVm.answer.values[1], 'Wilhelmina', 'Checking checkbox does not change text field')
       })
 
       it('should set error state from number prevalidation', () => {
@@ -345,23 +343,23 @@ describe('<a2j-field>', () => {
         const numberDollarEl = document.getElementById('Salary')
         numberDollarEl.value = 'safsd'
         numberDollarEl.dispatchEvent(e)
-        const hasError = numberDollarVm.attr('groupValidationMap').attr('Salary')
+        const hasError = numberDollarVm.groupValidationMap.Salary
         assert.equal(hasError, true, 'pre-validation should catch number errors and update groupValidationMap')
       })
     })
 
     describe('Calculator', () => {
       it('should show the calculator image when selected', () => {
-        let numberDollarField = numberDollarVm.attr('field')
-        numberDollarField.attr('calculator', true)
+        let numberDollarField = numberDollarVm.field
+        numberDollarField.calculator = true
 
         let $calcFound = $('.calc-icon')
         assert.equal($calcFound.length, 1, 'should find one .calc-icon element')
       })
 
       it('should not show the calculator image when unselected', () => {
-        let numberDollarField = numberDollarVm.attr('field')
-        numberDollarField.attr('calculator', false)
+        let numberDollarField = numberDollarVm.field
+        numberDollarField.calculator = false
 
         let $calcFound = $('.calc-icon')
 
@@ -371,7 +369,7 @@ describe('<a2j-field>', () => {
 
     describe('textpick ignores first onChange validation when field is set to `required`', () => {
       it('field.errors should be false, then true', () => {
-        const textpick = textpickVm.attr('field')
+        const textpick = textpickVm.field
         const el = document.querySelector('select')
 
         // textpick field types set default value to empty string
@@ -379,7 +377,7 @@ describe('<a2j-field>', () => {
         // and immediate error state before a user has a chance to answer
 
         // emulate initial value set
-        textpick.attr('_answerVm').attr('values', '')
+        textpick._answerVm.values = ''
         // emulate onChange validation
         let hasErrors = textpickVm.validateField(null, el)
         assert.equal(hasErrors, undefined, 'skips validateField, so hasErrors should be undefined')

--- a/src/mobile/pages/fields/field/field-test.js
+++ b/src/mobile/pages/fields/field/field-test.js
@@ -250,12 +250,12 @@ describe('<a2j-field>', () => {
         lang: new Lang(),
         groupValidationMap: new DefineMap(),
         lastIndexMap: new DefineMap(),
-        appState: {
+        appState: new AppState({
           traceMessage: new TraceMessage({
             currentPageName: 'FieldTest'
           }),
           userAvatar: {}
-        }
+        })
       }
 
       const fieldModels = [

--- a/src/mobile/pages/fields/field/field.js
+++ b/src/mobile/pages/fields/field/field.js
@@ -445,6 +445,7 @@ export const FieldVM = DefineMap.extend('FieldVM', {
         field,
         textlongVM
       })
+      $('#pageModal').modal('show')
     }
   },
 

--- a/src/mobile/pages/fields/field/field.js
+++ b/src/mobile/pages/fields/field/field.js
@@ -46,12 +46,12 @@ export const FieldVM = CanMap.extend('FieldVM', {
     groupValidationMap: {},
     lastIndexMap: {},
     // Type: DefineMap
-    rState: {},
+    appState: {},
 
     // used in field views/*
     repeatVarValue: {
       get () {
-        return this.attr('rState').repeatVarValue
+        return this.attr('appState').repeatVarValue
       }
     },
 
@@ -75,7 +75,7 @@ export const FieldVM = CanMap.extend('FieldVM', {
      */
     userAvatar: {
       get () {
-        return this.attr('rState').userAvatar
+        return this.attr('appState').userAvatar
       }
     },
 
@@ -178,7 +178,7 @@ export const FieldVM = CanMap.extend('FieldVM', {
     savedGenderValue: {
       get: function () {
         let name = this.attr('field.name').toLowerCase()
-        let answerIndex = this.attr('rState.answerIndex')
+        let answerIndex = this.attr('appState.answerIndex')
         let answers = this.attr('logic.interview.answers')
         if (name && answers) {
           return answers.attr(name).attr('values.' + answerIndex)
@@ -339,7 +339,7 @@ export const FieldVM = CanMap.extend('FieldVM', {
         { format: 'val', msg: value }
       ]
     }
-    this.attr('rState').traceMessage.addMessage(message)
+    this.attr('appState').traceMessage.addMessage(message)
   },
 
   /**
@@ -426,7 +426,7 @@ export const FieldVM = CanMap.extend('FieldVM', {
    */
   expandTextlong (field) {
     const answerName = field.attr('name')
-    const previewActive = this.attr('rState.previewActive')
+    const previewActive = this.attr('appState.previewActive')
     // warning modal only in Author
     if (!answerName && previewActive) {
       this.attr('modalContent', { title: 'Author Warning', text: 'Text(long) fields require an assigned variable to expand' })

--- a/src/mobile/pages/fields/field/field.js
+++ b/src/mobile/pages/fields/field/field.js
@@ -41,7 +41,7 @@ stache.registerPartial('exceeded-maxchars-tpl', exceededMaxcharsTpl)
 export const FieldVM = CanMap.extend('FieldVM', {
   define: {
     // passed in via fields.stache binding
-    field: {},
+    field: {}, // Field Model is a DefineMap
     fieldIndex: {},
     groupValidationMap: {},
     lastIndexMap: {},
@@ -133,8 +133,8 @@ export const FieldVM = CanMap.extend('FieldVM', {
     invalidPrompt: {
       get () {
         let field = this.attr('field')
-        let defaultInvalidPrompt = this.attr('lang')['FieldPrompts_' + field.attr('type')]
-        return field.attr('invalidPrompt') || defaultInvalidPrompt
+        let defaultInvalidPrompt = this.attr('lang')['FieldPrompts_' + field.type]
+        return field.invalidPrompt || defaultInvalidPrompt
       }
     },
 
@@ -284,7 +284,7 @@ export const FieldVM = CanMap.extend('FieldVM', {
   validateField (ctx, el) {
     const $el = $(el)
     let field = this.attr('field')
-    let _answerVm = field.attr('_answerVm')
+    let _answerVm = field._answerVm
     let value
 
     // textpick binding fired onChange even on first load
@@ -309,12 +309,12 @@ export const FieldVM = CanMap.extend('FieldVM', {
       value = $el.val()
     }
 
-    _answerVm.attr('values', value)
+    _answerVm.values = value
 
-    let errors = _answerVm.attr('errors')
-    field.attr('hasError', errors)
+    let errors = _answerVm.errors
+    field.hasError = errors
     // update group validation for radio buttons
-    const varName = field.attr('name')
+    const varName = field.name
     this.attr('groupValidationMap').attr(varName, !!errors)
 
     if (!errors) {
@@ -325,9 +325,9 @@ export const FieldVM = CanMap.extend('FieldVM', {
   },
 
   debugPanelMessage (field, value) {
-    const answerName = field.attr('name')
-    const answerIndex = field.attr('_answerVm.answerIndex')
-    const isRepeating = field.attr('_answerVm.answer.repeating')
+    const answerName = field.name
+    const answerIndex = field._answerVm.answerIndex
+    const isRepeating = field._answerVm.answer.repeating
     // if repeating true, show var#count in debug-panel
     const displayAnswerIndex = isRepeating ? `#${answerIndex}` : ''
 
@@ -352,15 +352,15 @@ export const FieldVM = CanMap.extend('FieldVM', {
   preValidateNumber (ctx, el) {
     const $el = $(el)
     const field = this.attr('field')
-    const varName = field.attr('name')
+    const varName = field.name
     // accept only numbers, commas, periods, and negative sign
     const currentValue = $el.val()
     const scrubbedValue = currentValue.replace(/[^\d.,-]/g, '')
     if (currentValue !== scrubbedValue) {
-      field.attr('hasError', true)
+      field.hasError = true
       this.attr('groupValidationMap').attr(varName, true)
     } else {
-      field.attr('hasError', false)
+      field.hasError = false
       this.attr('groupValidationMap').attr(varName, false)
     }
   },
@@ -375,7 +375,7 @@ export const FieldVM = CanMap.extend('FieldVM', {
   showCalculator (field) {
     if (field && field.calculator === true) {
       const vm = this
-      const inputId = field.attr('label')
+      const inputId = field.label
       const $inputEl = $("[id='" + inputId + "']")
       $inputEl.calculator({
         showOn: 'operator',
@@ -386,7 +386,7 @@ export const FieldVM = CanMap.extend('FieldVM', {
           const field = vm.attr('field')
 
           // set answer and validate
-          field.attr('_answerVm.values', calcValue)
+          field._answerVm.values = calcValue
           vm.validateField(null, $el)
         },
         useText: 'Enter',
@@ -425,15 +425,15 @@ export const FieldVM = CanMap.extend('FieldVM', {
    *
    */
   expandTextlong (field) {
-    const answerName = field.attr('name')
+    const answerName = field.name
     const previewActive = this.attr('appState.previewActive')
     // warning modal only in Author
     if (!answerName && previewActive) {
       this.attr('modalContent', { title: 'Author Warning', text: 'Text(long) fields require an assigned variable to expand' })
     }
     if (answerName) {
-      const title = field.attr('label')
-      const textlongValue = field.attr('_answerVm.values')
+      const title = field.label
+      const textlongValue = field._answerVm.values
       const textlongVM = this
       this.attr('modalContent', {
         title,
@@ -446,7 +446,7 @@ export const FieldVM = CanMap.extend('FieldVM', {
   },
 
   fireModalClose (field, newValue, textlongVM) {
-    field.attr('_answerVm.values', newValue)
+    field._answerVm.values = newValue
     const selector = "[name='" + field.name + "']"
     const longtextEl = $(selector)[0]
     textlongVM.validateField(textlongVM, longtextEl)
@@ -501,12 +501,12 @@ export const FieldVM = CanMap.extend('FieldVM', {
   // other checkbox selections when nota is checked, and vice-versa
   notaCheckboxHandler (field, isChecked) {
     if (isChecked) {
-      const fields = field.attr('_answerVm.fields')
+      const fields = field._answerVm.fields
       if (fields) {
         const toStayChecked = field.type
         fields.forEach(function (field) {
           if (field.type !== toStayChecked && (field.type === 'checkbox' || field.type === 'checkboxNOTA')) {
-            field.attr('_answerVm.values', false)
+            field._answerVm.values = false
           }
         })
       }

--- a/src/mobile/pages/fields/field/field.js
+++ b/src/mobile/pages/fields/field/field.js
@@ -2,7 +2,6 @@ import $ from 'jquery'
 import DefineMap from 'can-define/map/map'
 import DefineList from 'can-define/list/list'
 import FieldModel from '~/src/models/field'
-import ModalContent from '~/src/modal/modal-content'
 import moment from 'moment'
 import views from './views/'
 import _range from 'lodash/range'
@@ -49,7 +48,11 @@ export const FieldVM = DefineMap.extend('FieldVM', {
   groupValidationMap: {},
   lastIndexMap: {},
   appState: {},
-  modalContent: {},
+  modalContent: {
+    get () {
+      return this.appState.modalContent
+    }
+  },
 
   // used in field views/*
   repeatVarValue: {
@@ -435,14 +438,13 @@ export const FieldVM = DefineMap.extend('FieldVM', {
       const title = field.label
       const textlongValue = field._answerVm.values
       const textlongVM = this
-      const modalContent = new ModalContent({
+      this.modalContent.assign({
         title,
         textlongValue,
         answerName,
         field,
         textlongVM
       })
-      this.modalContent = modalContent
     }
   },
 
@@ -589,8 +591,7 @@ export const FieldVM = DefineMap.extend('FieldVM', {
     groupValidationMap:from="groupValidationMap"
     lang:from="lang"
     logic:from="logic"
-    appState:from="appState"
-    modalContent:bind="modalContent" />
+    appState:from="appState"/>
  * @codeend
  */
 export default Component.extend('FieldComponent', {

--- a/src/mobile/pages/fields/field/field.js
+++ b/src/mobile/pages/fields/field/field.js
@@ -181,7 +181,7 @@ export const FieldVM = CanMap.extend('FieldVM', {
         let answerIndex = this.attr('appState.answerIndex')
         let answers = this.attr('logic.interview.answers')
         if (name && answers) {
-          return answers.attr(name).attr('values.' + answerIndex)
+          return answers.varGet(name, answerIndex)
         }
       }
     },

--- a/src/mobile/pages/fields/field/field.js
+++ b/src/mobile/pages/fields/field/field.js
@@ -1,7 +1,9 @@
 import $ from 'jquery'
-import CanMap from 'can-map'
+import DefineMap from 'can-define/map/map'
+import DefineList from 'can-define/list/list'
+import FieldModel from '~/src/models/field'
+import ModalContent from '~/src/modal/modal-content'
 import moment from 'moment'
-import CanList from 'can-list'
 import views from './views/'
 import _range from 'lodash/range'
 import _isNaN from 'lodash/isNaN'
@@ -19,7 +21,6 @@ import 'jquery-ui/ui/widgets/datepicker'
 import '~/src/calculator/jquery.plugin'
 import '~/src/calculator/jquery.calculator'
 import '~/src/calculator/jquery.calculator.css'
-import 'can-map-define'
 
 function getBaseUrl () {
   return window.System.baseURL
@@ -38,202 +39,201 @@ stache.registerPartial('exceeded-maxchars-tpl', exceededMaxcharsTpl)
  *
  * `<a2j-field>`'s viewModel.
  */
-export const FieldVM = CanMap.extend('FieldVM', {
-  define: {
-    // passed in via fields.stache binding
-    field: {}, // Field Model is a DefineMap
-    fieldIndex: {},
-    groupValidationMap: {},
-    lastIndexMap: {},
-    // Type: DefineMap
-    appState: {},
+export const FieldVM = DefineMap.extend('FieldVM', {
+  // passed in via fields.stache binding
+  lang: {},
+  field: {
+    Type: FieldModel
+  },
+  fieldIndex: {},
+  groupValidationMap: {},
+  lastIndexMap: {},
+  appState: {},
+  modalContent: {},
 
-    // used in field views/*
-    repeatVarValue: {
-      get () {
-        return this.attr('appState').repeatVarValue
-      }
-    },
+  // used in field views/*
+  repeatVarValue: {
+    get () {
+      return this.appState.repeatVarValue
+    }
+  },
 
-    /**
-     * @property {can.compute} field.ViewModel.prototype.isMobile isMobile
-     *
-     * used to detect mobile viewer loaded
-     *
-     * */
-    isMobile: {
-      get () {
-        return isMobile()
-      }
-    },
+  /**
+   * @property {can.compute} field.ViewModel.prototype.isMobile isMobile
+   *
+   * used to detect mobile viewer loaded
+   *
+   * */
+  isMobile: {
+    get () {
+      return isMobile()
+    }
+  },
 
-    /**
-     * @property {DefineMap} field.ViewModel.prototype.userAvatar userAvatar
-     * @parent field.ViewModel
-     *
-     *  current userAvatar
-     */
-    userAvatar: {
-      get () {
-        return this.attr('appState').userAvatar
-      }
-    },
+  /**
+   * @property {DefineMap} field.ViewModel.prototype.userAvatar userAvatar
+   * @parent field.ViewModel
+   *
+   *  current userAvatar
+   */
+  userAvatar: {
+    get () {
+      return this.appState.userAvatar
+    }
+  },
 
-    /**
-     * @property {Boolean} field.ViewModel.prototype.hasError hasError
-     * @parent field.ViewModel
-     *
-     * Tracks if field has invalid answer based on constraints ie: min, max, required, etc
-     */
-    hasError: {},
+  /**
+   * @property {Boolean} field.ViewModel.prototype.hasError hasError
+   * @parent field.ViewModel
+   *
+   * Tracks if field has invalid answer based on constraints ie: min, max, required, etc
+   */
+  hasError: {},
 
-    /**
-     * @property {List} field.ViewModel.prototype.numberPickOptions numberPickOptions
-     * @parent field.ViewModel
-     *
-     * List of integers used to render the `select` tag options when the field
-     * type is 'numberpick'. e.g, if `field.min` is `1` and and `field.max` is
-     * `5`, this property would return `[1, 2, 3, 4, 5]`.
-     */
-    numberPickOptions: {
-      get () {
-        const min = parseInt(this.attr('field.min'), 10)
-        const max = parseInt(this.attr('field.max'), 10)
-        const options = (_isNaN(min) || _isNaN(max)) ? [] : _range(min, max + 1)
+  /**
+   * @property {List} field.ViewModel.prototype.numberPickOptions numberPickOptions
+   * @parent field.ViewModel
+   *
+   * List of integers used to render the `select` tag options when the field
+   * type is 'numberpick'. e.g, if `field.min` is `1` and and `field.max` is
+   * `5`, this property would return `[1, 2, 3, 4, 5]`.
+   */
+  numberPickOptions: {
+    get () {
+      const min = parseInt(this.field.min, 10)
+      const max = parseInt(this.field.max, 10)
+      const options = (_isNaN(min) || _isNaN(max)) ? [] : _range(min, max + 1)
 
-        return new CanList(options)
-      }
-    },
+      return new DefineList(options)
+    }
+  },
 
-    /**
-     * @property {Boolean} field.ViewModel.prototype.showInvalidPrompt showInvalidPrompt
-     * @parent field.ViewModel
-     *
-     * Whether a prompt should be shown to indicate the field's answer is invalid
-     *
-     */
-    showInvalidPrompt: {
-      get () {
-        const varName = this.attr('field.name')
-        const lastIndex = this.attr('lastIndexMap') && this.attr('lastIndexMap').attr(varName)
-        const isLastIndex = this.attr('fieldIndex') === lastIndex
-        const hasGroupError = this.attr('groupValidationMap') && this.attr('groupValidationMap').attr(varName)
+  /**
+   * @property {Boolean} field.ViewModel.prototype.showInvalidPrompt showInvalidPrompt
+   * @parent field.ViewModel
+   *
+   * Whether a prompt should be shown to indicate the field's answer is invalid
+   *
+   */
+  showInvalidPrompt: {
+    get () {
+      const varName = this.field.name
+      const lastIndex = this.lastIndexMap && this.lastIndexMap[varName]
+      const isLastIndex = this.fieldIndex === lastIndex
+      const hasGroupError = this.groupValidationMap && this.groupValidationMap[varName]
 
-        return hasGroupError && isLastIndex && this.attr('invalidPrompt')
-      }
-    },
+      return hasGroupError && isLastIndex && this.invalidPrompt
+    }
+  },
 
-    /**
-     * @property {String} field.ViewModel.prototype.invalidPrompt invalidPrompt
-     * @parent field.ViewModel
-     *
-     * The prompt that should be shown when a field's answer is invalid
-     *
-     */
-    invalidPrompt: {
-      get () {
-        let field = this.attr('field')
-        let defaultInvalidPrompt = this.attr('lang')['FieldPrompts_' + field.type]
-        return field.invalidPrompt || defaultInvalidPrompt
-      }
-    },
+  /**
+   * @property {String} field.ViewModel.prototype.invalidPrompt invalidPrompt
+   * @parent field.ViewModel
+   *
+   * The prompt that should be shown when a field's answer is invalid
+   *
+   */
+  invalidPrompt: {
+    get () {
+      let field = this.field
+      let defaultInvalidPrompt = this.lang['FieldPrompts_' + field.type]
+      return field.invalidPrompt || defaultInvalidPrompt
+    }
+  },
 
-    /**
-     * @property {Boolean} field.ViewModel.prototype.showMinMaxPrompt showMinMaxPrompt
-     * @parent field.ViewModel
-     *
-     * Whether a prompt should be shown to indicate the field's min and max values
-     *
-     */
-    showMinMaxPrompt: {
-      get () {
-        const min = this.attr('field.min')
-        const max = this.attr('field.max')
-        return !!(min || max)
-      }
-    },
+  /**
+   * @property {Boolean} field.ViewModel.prototype.showMinMaxPrompt showMinMaxPrompt
+   * @parent field.ViewModel
+   *
+   * Whether a prompt should be shown to indicate the field's min and max values
+   *
+   */
+  showMinMaxPrompt: {
+    get () {
+      const min = this.field.min
+      const max = this.field.max
+      return !!(min || max)
+    }
+  },
 
-    /**
-     * @property {String} field.ViewModel.prototype.minMaxPrompt minMaxPrompt
-     * @parent field.ViewModel
-     *
-     * The prompt that should be shown when a field's answer is out of min/max range
-     *
-     */
-    minMaxPrompt: {
-      get () {
-        const min = this.attr('field.min') || 'any'
-        const max = this.attr('field.max') || 'any'
-        return `(${min} ~~~ ${max})`
-      }
-    },
+  /**
+   * @property {String} field.ViewModel.prototype.minMaxPrompt minMaxPrompt
+   * @parent field.ViewModel
+   *
+   * The prompt that should be shown when a field's answer is out of min/max range
+   *
+   */
+  minMaxPrompt: {
+    get () {
+      const min = this.field.min || 'any'
+      const max = this.field.max || 'any'
+      return `(${min} ~~~ ${max})`
+    }
+  },
 
-    /**
-     * @property {String} field.ViewModel.prototype.savedGenderValue savedGenderValue
-     * @parent field.ViewModel
-     *
-     * Used to determine if gender radio button should be checked based on saved answer
-     *
-     */
-    savedGenderValue: {
-      get: function () {
-        let name = this.attr('field.name').toLowerCase()
-        let answerIndex = this.attr('appState.answerIndex')
-        let answers = this.attr('logic.interview.answers')
-        if (name && answers) {
-          return answers.varGet(name, answerIndex)
-        }
-      }
-    },
-
-    /**
-     * @property {String} field.ViewModel.prototype.suggestionText suggestionText
-     * @parent field.ViewModel
-     *
-     * Used to suggest input format for text strings
-     *
-     */
-
-    suggestionText: {
-      get: function () {
-        let fieldType = this.attr('field.type')
-        if (fieldType === 'numberssn') {
-          return '999-99-9999'
-        } else if (fieldType === 'numberphone') {
-          return '(555) 555-5555'
-        } else {
-          return ''
-        }
-      }
-    },
-
-    /**
-     * @property {Number} field.ViewModel.prototype.availableLength availableLength
-     * @parent field.ViewModel
-     *
-     * remaining allowed characters before maxChar limit is reached
-     *
-     */
-    availableLength: {
-      value: undefined
-    },
-
-    /**
-     * @property {Boolean} field.ViewModel.prototype.overCharacterLimit overCharacterLimit
-     * @parent field.ViewModel
-     *
-     * used to trigger messages when over the maxChars value
-     *
-     */
-    overCharacterLimit: {
-      get () {
-        return this.attr('availableLength') < 0
+  /**
+   * @property {String} field.ViewModel.prototype.savedGenderValue savedGenderValue
+   * @parent field.ViewModel
+   *
+   * Used to determine if gender radio button should be checked based on saved answer
+   *
+   */
+  savedGenderValue: {
+    get: function () {
+      let name = this.field.name.toLowerCase()
+      let answerIndex = this.appState.answerIndex
+      let answers = this.logic.interview.answers
+      if (name && answers) {
+        return answers.varGet(name, answerIndex)
       }
     }
   },
 
+  /**
+   * @property {String} field.ViewModel.prototype.suggestionText suggestionText
+   * @parent field.ViewModel
+   *
+   * Used to suggest input format for text strings
+   *
+   */
+
+  suggestionText: {
+    get: function () {
+      let fieldType = this.field.type
+      if (fieldType === 'numberssn') {
+        return '999-99-9999'
+      } else if (fieldType === 'numberphone') {
+        return '(555) 555-5555'
+      } else {
+        return ''
+      }
+    }
+  },
+
+  /**
+   * @property {Number} field.ViewModel.prototype.availableLength availableLength
+   * @parent field.ViewModel
+   *
+   * remaining allowed characters before maxChar limit is reached
+   *
+   */
+  availableLength: {},
+
+  /**
+   * @property {Boolean} field.ViewModel.prototype.overCharacterLimit overCharacterLimit
+   * @parent field.ViewModel
+   *
+   * used to trigger messages when over the maxChars value
+   *
+   */
+  overCharacterLimit: {
+    get () {
+      return this.availableLength < 0
+    }
+  },
+
   onUserAvatarChange (selectedAvatar) {
-    const userAvatar = this.attr('userAvatar')
+    const userAvatar = this.userAvatar
 
     userAvatar.gender = selectedAvatar.gender
     userAvatar.isOld = selectedAvatar.isOld
@@ -243,14 +243,14 @@ export const FieldVM = CanMap.extend('FieldVM', {
   },
 
   onUserAvatarSkinToneChange (skinTone) {
-    const userAvatar = this.attr('userAvatar')
+    const userAvatar = this.userAvatar
     userAvatar.skinTone = skinTone
 
     this.validateField()
   },
 
   onUserAvatarHairColorChange (hairColor) {
-    const userAvatar = this.attr('userAvatar')
+    const userAvatar = this.userAvatar
     userAvatar.hairColor = hairColor
 
     this.validateField()
@@ -265,11 +265,11 @@ export const FieldVM = CanMap.extend('FieldVM', {
      */
 
   calcAvailableLength (ev) {
-    let maxChars = this.attr('field.maxChars')
+    let maxChars = this.field.maxChars
     let availableLengthValue
     if (maxChars) {
       availableLengthValue = (maxChars - ev.target.value.length)
-      this.attr('availableLength', availableLengthValue)
+      this.availableLength = availableLengthValue
     }
     return availableLengthValue
   },
@@ -283,7 +283,7 @@ export const FieldVM = CanMap.extend('FieldVM', {
    */
   validateField (ctx, el) {
     const $el = $(el)
-    let field = this.attr('field')
+    let field = this.field
     let _answerVm = field._answerVm
     let value
 
@@ -299,7 +299,7 @@ export const FieldVM = CanMap.extend('FieldVM', {
       value = $el[0].checked
       this.notaCheckboxHandler(field, value)
     } else if (field.type === 'useravatar') { // TODO: validate the JSON string here?
-      value = JSON.stringify(this.attr('userAvatar').serialize())
+      value = JSON.stringify(this.userAvatar.serialize())
     } else if (field.type === 'datemdy') {
       // format date to (mm/dd/yyyy) from acceptable inputs
       value = this.normalizeDateInput($el.val())
@@ -315,7 +315,7 @@ export const FieldVM = CanMap.extend('FieldVM', {
     field.hasError = errors
     // update group validation for radio buttons
     const varName = field.name
-    this.attr('groupValidationMap').attr(varName, !!errors)
+    this.groupValidationMap[varName] = !!errors
 
     if (!errors) {
       this.debugPanelMessage(field, value)
@@ -339,7 +339,7 @@ export const FieldVM = CanMap.extend('FieldVM', {
         { format: 'val', msg: value }
       ]
     }
-    this.attr('appState').traceMessage.addMessage(message)
+    this.appState.traceMessage.addMessage(message)
   },
 
   /**
@@ -351,17 +351,17 @@ export const FieldVM = CanMap.extend('FieldVM', {
    */
   preValidateNumber (ctx, el) {
     const $el = $(el)
-    const field = this.attr('field')
+    const field = this.field
     const varName = field.name
     // accept only numbers, commas, periods, and negative sign
     const currentValue = $el.val()
     const scrubbedValue = currentValue.replace(/[^\d.,-]/g, '')
     if (currentValue !== scrubbedValue) {
       field.hasError = true
-      this.attr('groupValidationMap').attr(varName, true)
+      this.groupValidationMap[varName] = true
     } else {
       field.hasError = false
-      this.attr('groupValidationMap').attr(varName, false)
+      this.groupValidationMap[varName] = false
     }
   },
 
@@ -383,7 +383,7 @@ export const FieldVM = CanMap.extend('FieldVM', {
         onClose: function (calcValue, instance) {
           const $el = instance.elem
           const vm = $el.prop('vm')
-          const field = vm.attr('field')
+          const field = vm.field
 
           // set answer and validate
           field._answerVm.values = calcValue
@@ -426,22 +426,23 @@ export const FieldVM = CanMap.extend('FieldVM', {
    */
   expandTextlong (field) {
     const answerName = field.name
-    const previewActive = this.attr('appState.previewActive')
+    const previewActive = this.appState.previewActive
     // warning modal only in Author
     if (!answerName && previewActive) {
-      this.attr('modalContent', { title: 'Author Warning', text: 'Text(long) fields require an assigned variable to expand' })
+      this.assign('modalContent', { title: 'Author Warning', text: 'Text(long) fields require an assigned variable to expand' })
     }
     if (answerName) {
       const title = field.label
       const textlongValue = field._answerVm.values
       const textlongVM = this
-      this.attr('modalContent', {
+      const modalContent = new ModalContent({
         title,
         textlongValue,
         answerName,
         field,
         textlongVM
       })
+      this.modalContent = modalContent
     }
   },
 
@@ -522,11 +523,11 @@ export const FieldVM = CanMap.extend('FieldVM', {
   connectedCallback (el) {
     const vm = this
     // default availableLength
-    vm.attr('availableLength', vm.attr('field.maxChars'))
+    vm.availableLength = vm.field.maxChars
 
     // userAvatar stored as json string and needs manual restore aka not bound in stache
-    if (vm.attr('field.type') === 'useravatar') {
-      const userAvatarJSON = vm.attr('logic').varGet('user avatar')
+    if (vm.field.type === 'useravatar') {
+      const userAvatarJSON = vm.logic.varGet('user avatar')
       if (userAvatarJSON) {
         vm.restoreUserAvatar(userAvatarJSON)
       }
@@ -536,14 +537,14 @@ export const FieldVM = CanMap.extend('FieldVM', {
     // TODO: src url assumes a2jviewer app is sibling of a2jauthor app for preview
     const datepickerButtonSvg = joinBaseUrl('images/datepicker-button.svg')
 
-    if (vm.attr('field.type') === 'datemdy') {
-      const defaultDate = vm.attr('field._answerVm.values')
-        ? vm.normalizeDateInput(vm.attr('field._answerVm.values')) : null
+    if (vm.field.type === 'datemdy') {
+      const defaultDate = vm.field._answerVm.values
+        ? vm.normalizeDateInput(vm.field._answerVm.values) : null
       // TODO: these dates need to be internationalized for output/input format
       // min/max values currently only come in as mm/dd/yyyy, or special value, TODAY, which is handled in convertDate above
-      const minDate = vm.convertDate(vm.attr('field.min'), null, 'MM/DD/YYYY') || null
-      const maxDate = vm.convertDate(vm.attr('field.max'), null, 'MM/DD/YYYY') || null
-      const lang = vm.attr('lang')
+      const minDate = vm.convertDate(vm.field.min, null, 'MM/DD/YYYY') || null
+      const maxDate = vm.convertDate(vm.field.max, null, 'MM/DD/YYYY') || null
+      const lang = vm.lang
 
       $('input.datepicker-input', $(el)).datepicker({
         showOn: 'button',
@@ -581,12 +582,15 @@ export const FieldVM = CanMap.extend('FieldVM', {
  *
  * ## use
  * @codestart
- * <a2j-field
- *    {(field)}="field
- *    {repeat-var-value}="repeatVarValue"
- *    {(logic)}="logic"
- *    {lang}="lang"
- *    {(trace-message)}="traceMessage" />
+  <a2j-field
+    field:from="field"
+    fieldIndex:from="scope.index"
+    lastIndexMap:from="lastIndexMap"
+    groupValidationMap:from="groupValidationMap"
+    lang:from="lang"
+    logic:from="logic"
+    appState:from="appState"
+    modalContent:bind="modalContent" />
  * @codeend
  */
 export default Component.extend('FieldComponent', {
@@ -609,10 +613,10 @@ export default Component.extend('FieldComponent', {
           if (!str) { return }
           str = typeof str === 'function' ? str() : str
           // re-eval if answer values have updated via beforeCode
-          const interview = self.attr('logic.interview')
-          const answersChanged = interview && interview.attr('answers').serialize() // eslint-disable-line
+          const interview = self.logic.interview
+          const answersChanged = interview && interview.answers.serialize() // eslint-disable-line
 
-          return self.attr('logic').eval(str)
+          return self.logic.eval(str)
         },
 
         dateformat (val, format) {
@@ -621,7 +625,7 @@ export default Component.extend('FieldComponent', {
 
         i18n (key) {
           key = typeof key === 'function' ? key() : key
-          return self.attr('lang')[key] || key
+          return self.lang[key] || key
         }
       })
     }

--- a/src/mobile/pages/fields/fields-test.html
+++ b/src/mobile/pages/fields/fields-test.html
@@ -8,7 +8,7 @@
     <div id="mocha"></div>
     <div id="test-area"></div>
 
-    <script src="../../../node_modules/steal/steal.js"
+    <script src="../../../../node_modules/steal/steal.js"
       data-mocha="bdd"
       data-main="~/src/mobile/pages/fields/fields-test"></script>
   </body>

--- a/src/mobile/pages/fields/fields-test.js
+++ b/src/mobile/pages/fields/fields-test.js
@@ -1,5 +1,6 @@
 import { assert } from 'chai'
 import { FieldsVM } from './fields'
+import Field from '~/src/models/field'
 import 'steal-mocha'
 
 describe('<a2j-fields>', () => {
@@ -8,13 +9,13 @@ describe('<a2j-fields>', () => {
 
     beforeEach(() => {
       vm = new FieldsVM({
-        fields: [
+        fields: new Field.List([
           { name: 'foo' },
           { name: 'foo' },
           { name: 'foobaroo' },
           { name: 'baz' },
           { name: 'baz' }
-        ]
+        ])
       })
     })
 
@@ -29,18 +30,18 @@ describe('<a2j-fields>', () => {
         foobaroo: 2,
         baz: 4
       }
-      assert.deepEqual(vm.attr('lastIndexMap').serialize(), expectedResults, 'should build lastIndexMap based on passed in fields')
+      assert.deepEqual(vm.lastIndexMap.serialize(), expectedResults, 'should build lastIndexMap based on passed in fields')
 
       expectedResults = {}
-      vm.attr('fields', [])
-      assert.deepEqual(vm.attr('lastIndexMap').serialize(), expectedResults, 'lastIndexMap should handle no fields')
+      vm.fields = []
+      assert.deepEqual(vm.lastIndexMap.serialize(), expectedResults, 'lastIndexMap should handle no fields')
 
       expectedResults = {
         foo: 0,
         bar: 2
       }
-      vm.attr('fields', [{name: 'foo'}, {name: 'bar'}, {name: 'bar'}])
-      assert.deepEqual(vm.attr('lastIndexMap').serialize(), expectedResults, 'lastIndexMap should update when fields changes')
+      vm.fields = [{name: 'foo'}, {name: 'bar'}, {name: 'bar'}]
+      assert.deepEqual(vm.lastIndexMap.serialize(), expectedResults, 'lastIndexMap should update when fields changes')
     })
 
     it('groupValidationMap', () => {
@@ -50,18 +51,18 @@ describe('<a2j-fields>', () => {
         foobaroo: false,
         baz: false
       }
-      assert.deepEqual(vm.attr('groupValidationMap').serialize(), expectedResults, 'should build groupValidationMap based on passed in fields')
+      assert.deepEqual(vm.groupValidationMap.serialize(), expectedResults, 'should build groupValidationMap based on passed in fields')
 
       expectedResults = {}
-      vm.attr('fields', [])
-      assert.deepEqual(vm.attr('groupValidationMap').serialize(), expectedResults, 'groupValidationMap should handle no fields')
+      vm.fields = []
+      assert.deepEqual(vm.groupValidationMap.serialize(), expectedResults, 'groupValidationMap should handle no fields')
 
       expectedResults = {
         foo: false,
         bar: false
       }
-      vm.attr('fields', [{name: 'foo'}, {name: 'bar'}, {name: 'bar'}])
-      assert.deepEqual(vm.attr('groupValidationMap').serialize(), expectedResults, 'groupValidationMap should update when fields changes')
+      vm.fields = [{name: 'foo'}, {name: 'bar'}, {name: 'bar'}]
+      assert.deepEqual(vm.groupValidationMap.serialize(), expectedResults, 'groupValidationMap should update when fields changes')
     })
   })
 })

--- a/src/mobile/pages/fields/fields.js
+++ b/src/mobile/pages/fields/fields.js
@@ -17,7 +17,7 @@ export const FieldsVM = CanMap.extend('FieldsVM', {
     lang: {},
     logic: {},
     fields: {},
-    rState: {},
+    appState: {},
     modalContent: {},
 
     lastIndexMap: {},

--- a/src/mobile/pages/fields/fields.js
+++ b/src/mobile/pages/fields/fields.js
@@ -1,9 +1,8 @@
-import CanMap from 'can-map'
+import DefineMap from 'can-define/map/map'
 import Component from 'can-component'
 import template from './fields.stache'
 
 import '~/src/mobile/pages/fields/field/'
-import 'can-map-define'
 
 /**
  * @property {can.Map} fields.ViewModel
@@ -11,28 +10,26 @@ import 'can-map-define'
  *
  * `<a2j-fields>`'s viewModel.
  */
-export const FieldsVM = CanMap.extend('FieldsVM', {
-  define: {
-    // passed in via pages.stache bindings
-    lang: {},
-    logic: {},
-    fields: {},
-    appState: {},
-    modalContent: {},
+export const FieldsVM = DefineMap.extend('FieldsVM', {
+  // passed in via pages.stache bindings
+  lang: {},
+  logic: {},
+  fields: {},
+  appState: {},
+  modalContent: {},
 
-    lastIndexMap: {},
+  lastIndexMap: {},
 
-    groupValidationMap: {}
-  },
+  groupValidationMap: {},
 
   buildGroupValidationMap () {
-    const fields = this.attr('fields')
-    const groupValidationMap = new CanMap()
+    const fields = this.fields
+    const groupValidationMap = new DefineMap()
 
     if (fields.length) {
       fields.forEach((field) => {
         const varName = field.name
-        groupValidationMap.attr(varName, false)
+        groupValidationMap.set(varName, false)
       })
     }
 
@@ -40,13 +37,13 @@ export const FieldsVM = CanMap.extend('FieldsVM', {
   },
 
   buildLastIndexMap () {
-    const fields = this.attr('fields')
-    const lastIndexMap = new CanMap()
+    const fields = this.fields
+    const lastIndexMap = new DefineMap()
 
     if (fields.length) {
       fields.forEach((field, index) => {
         const varName = field.name
-        lastIndexMap.attr(varName, index)
+        lastIndexMap.set(varName, index)
       })
     }
 
@@ -55,14 +52,19 @@ export const FieldsVM = CanMap.extend('FieldsVM', {
 
   connectedCallback () {
     // first page
-    this.attr('groupValidationMap', this.buildGroupValidationMap())
-    this.attr('lastIndexMap', this.buildLastIndexMap())
+    this.groupValidationMap = this.buildGroupValidationMap()
+    this.lastIndexMap = this.buildLastIndexMap()
 
+    const fieldsHandler = () => {
+      this.groupValidationMap = this.buildGroupValidationMap()
+      this.lastIndexMap = this.buildLastIndexMap()
+    }
     // navigated pages which resets fields list
-    this.listenTo('fields', () => {
-      this.attr('groupValidationMap', this.buildGroupValidationMap())
-      this.attr('lastIndexMap', this.buildLastIndexMap())
-    })
+    this.listenTo('fields', fieldsHandler)
+
+    return () => {
+      this.stopListening('fields', fieldsHandler)
+    }
   }
 })
 

--- a/src/mobile/pages/fields/fields.js
+++ b/src/mobile/pages/fields/fields.js
@@ -16,7 +16,11 @@ export const FieldsVM = DefineMap.extend('FieldsVM', {
   logic: {},
   fields: {},
   appState: {},
-  modalContent: {},
+  modalContent: {
+    get () {
+      return this.appState.modalContent
+    }
+  },
 
   lastIndexMap: {},
 

--- a/src/mobile/pages/fields/fields.js
+++ b/src/mobile/pages/fields/fields.js
@@ -31,7 +31,7 @@ export const FieldsVM = CanMap.extend('FieldsVM', {
 
     if (fields.length) {
       fields.forEach((field) => {
-        const varName = field.attr('name')
+        const varName = field.name
         groupValidationMap.attr(varName, false)
       })
     }
@@ -45,7 +45,7 @@ export const FieldsVM = CanMap.extend('FieldsVM', {
 
     if (fields.length) {
       fields.forEach((field, index) => {
-        const varName = field.attr('name')
+        const varName = field.name
         lastIndexMap.attr(varName, index)
       })
     }

--- a/src/mobile/pages/fields/fields.stache
+++ b/src/mobile/pages/fields/fields.stache
@@ -6,7 +6,6 @@
     groupValidationMap:from="groupValidationMap"
     lang:from="lang"
     logic:from="logic"
-    repeatVarValue:from="appState.repeatVarValue"
     appState:from="appState"
     modalContent:bind="modalContent" />
 {{/for}}

--- a/src/mobile/pages/fields/fields.stache
+++ b/src/mobile/pages/fields/fields.stache
@@ -6,7 +6,7 @@
     groupValidationMap:from="groupValidationMap"
     lang:from="lang"
     logic:from="logic"
-    repeatVarValue:from="rState.repeatVarValue"
-    rState:from="rState"
+    repeatVarValue:from="appState.repeatVarValue"
+    appState:from="appState"
     modalContent:bind="modalContent" />
 {{/for}}

--- a/src/mobile/pages/fields/fields.stache
+++ b/src/mobile/pages/fields/fields.stache
@@ -6,6 +6,5 @@
     groupValidationMap:from="groupValidationMap"
     lang:from="lang"
     logic:from="logic"
-    appState:from="appState"
-    modalContent:bind="modalContent" />
+    appState:from="appState" />
 {{/for}}

--- a/src/mobile/pages/pages-test.js
+++ b/src/mobile/pages/pages-test.js
@@ -1,10 +1,17 @@
 import $ from 'jquery'
+import DefineMap from 'can-define/map/map'
 import CanMap from 'can-map'
 import stache from 'can-stache'
 import { assert } from 'chai'
 import PagesVM from './pages-vm'
+import Lang from '~/src/mobile/util/lang'
 import AnswerVM from '~/src/models/answervm'
+import Answer from '~/src/models/answer'
+import Page from '~/src/models/page'
 import AppState from '~/src/models/app-state'
+import ModalContent from '~/src/modal/modal-content'
+import MemoryState from '~/src/models/memory-state'
+import FieldModel from '~/src/models/field'
 import TraceMessage from '@caliorg/a2jdeps/models/trace-message'
 import Interview from '~/src/models/interview'
 import Logic from '~/src/mobile/util/logic'
@@ -24,21 +31,20 @@ describe('<a2j-pages>', () => {
   let traceMessage
 
   beforeEach(() => {
-    nextPageStub = new CanMap({
+    nextPageStub = new Page({
       name: 'Next',
       step: { number: '1', text: 'Step 1' },
       fields: []
     })
 
-    priorPageStub = new CanMap({
+    priorPageStub = new Page({
       name: 'priorPage',
       step: { number: '1', text: 'Step 1' },
       fields: []
     })
 
     interview = new Interview({
-      answers: new CanMap(),
-      pages: new CanMap({nextPageStub, priorPageStub})
+      pages: [{nextPageStub, priorPageStub}]
     })
 
     logic = new Logic({interview})
@@ -46,7 +52,7 @@ describe('<a2j-pages>', () => {
     traceMessage = new TraceMessage()
 
     defaults = {
-      currentPage: new CanMap({
+      currentPage: new Page({
         name: 'Intro',
         fields: [],
         repeatVar: '',
@@ -57,11 +63,13 @@ describe('<a2j-pages>', () => {
         buttons: null,
         step: { number: '0', text: 'Step 0' } }
       ),
+      modalContent: new ModalContent(),
+      lang: new Lang(),
       logic: logic,
       appState: new AppState({ interview, logic, traceMessage }),
-      mState: { },
+      mState: new MemoryState(),
       interview,
-      groupValidationMap: new CanMap()
+      groupValidationMap: new DefineMap()
     }
 
     // initialize messages list in traceMessage
@@ -73,7 +81,7 @@ describe('<a2j-pages>', () => {
     beforeEach(() => {
       vm = new PagesVM(defaults)
       vm.connectedCallback()
-      appStateTeardown = vm.attr('appState').connectedCallback()
+      appStateTeardown = vm.appState.connectedCallback()
     })
 
     afterEach(() => {
@@ -86,7 +94,7 @@ describe('<a2j-pages>', () => {
         vm.listenTo('post-answers-to-server', () => {
           postCount++
         })
-        const button = new CanMap({ next: constants.qIDEXIT })
+        const button = new DefineMap({ next: constants.qIDEXIT })
 
         vm.navigate(button)
         assert.equal(postCount, 1, 'should fire post event')
@@ -98,27 +106,27 @@ describe('<a2j-pages>', () => {
       })
 
       it('getNextPage - check for normal nav or GOTO logic', () => {
-        const button = new CanMap({ next: 'foo' })
-        const currentPage = vm.attr('currentPage')
-        const logic = vm.attr('logic')
+        const button = new DefineMap({ next: 'foo' })
+        const currentPage = vm.currentPage
+        const logic = vm.logic
         logic.guide.pages = { Next: nextPageStub }
 
         const normalNavPage = vm.navigate(button)
         assert.equal(normalNavPage, 'foo', 'logic gotoPage should override button "next" value')
 
-        currentPage.attr('codeAfter', `GOTO "Next"`)
+        currentPage.codeAfter = `GOTO "Next"`
         const gotoPage = vm.navigate(button)
         assert.equal(gotoPage, 'Next', 'logic gotoPage should override button "next" value')
       })
 
       it('handleCodeAfter - process After Logic', () => {
-        const button = new CanMap({ next: 'foo' })
-        const currentPage = vm.attr('currentPage')
+        const button = new DefineMap({ next: 'foo' })
+        const currentPage = vm.currentPage
         let logicCount = 0
 
-        vm.attr('logic').exec = () => { logicCount++ }
+        vm.logic.exec = () => { logicCount++ }
 
-        currentPage.attr('codeAfter', 'GOTO [Next]')
+        currentPage.codeAfter = 'GOTO [Next]'
 
         vm.navigate(button)
 
@@ -126,30 +134,30 @@ describe('<a2j-pages>', () => {
       })
 
       it('handlePreviewResponses', () => {
-        const button = new CanMap({ next: constants.qIDSUCCESS })
+        const button = new DefineMap({ next: constants.qIDSUCCESS })
 
-        vm.attr('previewActive', true)
+        vm.previewActive = true
         vm.navigate(button)
-        const modalContent = vm.attr('modalContent')
+        const modalContent = vm.modalContent
 
         assert.equal(modalContent.text, `User's data would upload to the server.`, 'modalContent should update to display modal when previewActive')
       })
 
       it('ignores navigate() logic if fields have errors', () => {
-        const button = new CanMap({ next: 'foo' })
+        const button = new DefineMap({ next: 'foo' })
         const fieldWithError = { _answerVm: { errors: true } }
-        vm.attr('currentPage.fields').push(fieldWithError)
+        vm.currentPage.fields.push(fieldWithError)
 
         const shouldReturnFalse = vm.navigate(button)
         assert.equal(shouldReturnFalse, false, 'fields with errors return false')
       })
 
       it('navigates to prior question with BACK button', () => {
-        const appState = vm.attr('appState')
+        const appState = vm.appState
         const visitedPages = appState.visitedPages
-        const button = new CanMap({ next: constants.qIDBACK })
+        const button = new DefineMap({ next: constants.qIDBACK })
         visitedPages[0] = defaults.currentPage
-        visitedPages[1] = new CanMap({ name: 'priorPage' })
+        visitedPages[1] = new Page({ name: 'priorPage' })
 
         vm.navigate(button)
         assert.equal(appState.page, 'priorPage', 'should navigate to prior page')
@@ -158,17 +166,9 @@ describe('<a2j-pages>', () => {
       it('saves answer when button has a value with special buttons as next target', () => {
         let answers = defaults.interview.answers
 
-        let kidstf = new CanMap({
-          comment: '',
-          name: 'KidsTF',
-          repeating: true,
-          type: 'TF',
-          values: [null]
-        })
+        answers.varCreate('kidstf', 'TF', true)
 
-        answers.varSet('kidstf', kidstf)
-
-        const button = new CanMap({
+        const button = new DefineMap({
           label: 'Go!',
           next: constants.qIDFAIL,
           name: 'KidsTF',
@@ -185,17 +185,9 @@ describe('<a2j-pages>', () => {
       it('saves answer when button has a value', () => {
         let answers = defaults.interview.answers
 
-        let kidstf = new CanMap({
-          comment: '',
-          name: 'KidsTF',
-          repeating: true,
-          type: 'TF',
-          values: [null]
-        })
+        answers.varCreate('kidstf', 'TF', false)
 
-        answers.varSet('kidstf', kidstf)
-
-        const button = new CanMap({
+        const button = new DefineMap({
           label: 'Go!',
           next: 'Next',
           name: 'KidsTF',
@@ -212,26 +204,14 @@ describe('<a2j-pages>', () => {
         const answers = defaults.interview.answers
         const page = defaults.currentPage
 
-        const agesnu = new CanMap({
-          comment: '',
-          name: 'AgesNU',
-          repeating: true,
-          type: 'Number',
-          values: [null, 14, 12]
-        })
+        answers.varCreate('AgesNU', 'Number', true)
+        answers.varSet('AgesNU', 14, 1)
+        answers.varSet('AgesNU', 12, 2)
 
-        const count = new CanMap({
-          comment: '',
-          name: 'count',
-          repeating: false,
-          type: 'Number',
-          values: [null, 3]
-        })
+        answers.varCreate('count', 'Number', true)
+        answers.varSet('count', 3, 1)
 
-        answers.varSet('agesnu', agesnu)
-        answers.varSet('count', count)
-
-        const button = new CanMap({
+        const button = new DefineMap({
           label: 'Go!',
           next: 'Next',
           name: 'AgesNU',
@@ -239,7 +219,7 @@ describe('<a2j-pages>', () => {
         })
 
         // required to trigger mutli-value save
-        page.attr('repeatVar', 'count')
+        page.repeatVar = 'count'
 
         vm.navigate(button)
 
@@ -251,26 +231,20 @@ describe('<a2j-pages>', () => {
         const answers = defaults.interview.answers
         const incompleteTF = constants.vnInterviewIncompleteTF.toLowerCase()
 
-        const incomplete = new CanMap({
-          comment: '',
-          name: incompleteTF,
-          repeating: false,
-          type: 'TF',
-          values: [null, true]
-        })
+        answers.varCreate(incompleteTF, 'TF', false)
+        answers.varSet(incompleteTF, true, 1)
 
-        const specialButton = new CanMap({
+        const specialButton = new DefineMap({
           label: 'Special!',
           next: constants.qIDSUCCESS
         })
 
-        answers.varSet(incompleteTF, incomplete)
         vm.navigate(specialButton)
         assert.equal(answers.varGet(incompleteTF, 1), false, 'success button should complete interview')
       })
 
       it('handleCrossedUseOfResumeOrBack', () => {
-        const button = new CanMap({next: constants.qIDBACK})
+        const button = new DefineMap({next: constants.qIDBACK})
         let buttonNextTarget = vm.handleCrossedUseOfResumeOrBack(button, true)
         assert.equal(buttonNextTarget, constants.qIDRESUME, 'should update BackToPriorQuestion to Resume if on exitPage')
 
@@ -287,74 +261,53 @@ describe('<a2j-pages>', () => {
     it('validateAllFields', () => {
       let hasErrors = vm.validateAllFields()
       assert.isFalse(hasErrors, 'should return false if there are no fields')
-      console.log(vm.attr('currentPage').fields)
 
-      vm.attr('currentPage.fields', [{name: 'foo', _answerVm: {errors: true}}, {name: 'bar', _answerVm: {errors: false}}])
+      vm.currentPage.fields = [{name: 'foo', _answerVm: {errors: true}}, {name: 'bar', _answerVm: {errors: false}}]
       hasErrors = vm.validateAllFields()
-      assert.isTrue(hasErrors, 'should return true if at least one field is invalid')
-      assert.isTrue(vm.attr('currentPage.fields.0.hasError'), 'should set the field model hasError prop to true')
-      assert.isTrue(vm.attr('groupValidationMap').attr('foo'), 'should update the groupValidationMap for the matching field.name to true')
+      assert.isTrue(hasErrors, 'should return true if as at least one field is invalid')
+      assert.isTrue(vm.currentPage.fields[0].hasError, 'should set the field model hasError prop to true')
+      assert.isTrue(vm.groupValidationMap['foo'], 'should update the groupValidationMap for the matching field.name to true')
 
-      vm.attr('currentPage.fields', [{name: 'foo', _answerVm: {errors: false}}, {name: 'bar', _answerVm: {errors: false}}])
+      vm.currentPage.fields = [{name: 'foo', _answerVm: {errors: false}}, {name: 'bar', _answerVm: {errors: false}}]
       hasErrors = vm.validateAllFields()
       assert.isFalse(hasErrors, 'should return false if no fields are invalid')
-      assert.isFalse(vm.attr('currentPage.fields.0.hasError'), 'should set the field model hasError prop to false')
-      assert.isFalse(vm.attr('groupValidationMap').attr('foo'), 'should update the groupValidationMap for the matching field.name to false')
+      assert.isFalse(vm.currentPage.fields[0].hasError, 'should set the field model hasError prop to false')
+      assert.isFalse(vm.groupValidationMap['foo'], 'should update the groupValidationMap for the matching field.name to false')
     })
 
     it('setRepeatVariable', () => {
       const answers = defaults.interview.answers
-      const counter = new CanMap({
-        comment: '',
-        name: 'counter',
-        repeating: false,
-        type: 'Number',
-        values: [null]
-      })
+      answers.varCreate('count', 'Number', false)
 
-      answers.varSet('counter', counter)
-
-      const button = new CanMap({
+      const button = new DefineMap({
         repeatVar: 'counter',
         repeatVarSet: constants.RepeatVarSetOne
       })
 
       vm.setRepeatVariable(button)
-      assert(vm.attr('logic').varGet('counter'), 1, 'sets initial value to 1')
+      assert(vm.logic.varGet('counter'), 1, 'sets initial value to 1')
 
-      button.attr('repeatVarSet', constants.RepeatVarSetPlusOne)
+      button.repeatVarSet = constants.RepeatVarSetPlusOne
 
       vm.setRepeatVariable(button)
-      assert(vm.attr('logic').varGet('counter'), 1, 'increments counter to 2')
+      assert(vm.logic.varGet('counter'), 1, 'increments counter to 2')
     })
 
     it('setFieldAnswers with repeatVar', () => {
       const answers = defaults.interview.answers
-      const salaryCount = new CanMap({
-        comment: '',
-        name: 'salaryCount',
-        repeating: false,
-        type: 'NU',
-        values: [null, 2]
-      })
+      answers.varCreate('salaryCount', 'Number', false)
+      answers.varSet('salaryCount', 2, 1)
+      answers.varCreate('salary', 'Number', false)
+      answers.varSet('salary', 101, 1)
+      answers.varSet('salary', 202, 2)
 
-      const salary = new CanMap({
-        comment: '',
-        name: 'salary',
-        repeating: true,
-        type: 'NU',
-        values: [null, 101, 202]
-      })
+      vm.currentPage.repeatVar = 'salaryCount'
 
-      answers.varSet('salary', salary)
-      answers.varSet('salaryCount', salaryCount)
-      vm.attr('currentPage.repeatVar', 'salaryCount')
-
-      const fields = vm.attr('currentPage.fields')
+      const fields = vm.currentPage.fields
       fields.push({ name: 'salary', type: 'number' })
 
       vm.setFieldAnswers(fields)
-      const field = vm.attr('currentPage.fields.0')
+      const field = vm.currentPage.fields[0]
       const answerValues = field._answerVm.answer.values
 
       assert.deepEqual(answerValues.serialize(), [null, 101, 202], 'should set repeatVarValues')
@@ -362,40 +315,33 @@ describe('<a2j-pages>', () => {
 
     describe('default values', () => {
       it('sets default value', () => {
-        let field = new CanMap({
+        let field = new FieldModel({
           name: 'StateTE',
           label: 'Enter State:',
-          type: 'text',
+          type: 'Text',
           value: 'Texas'
         })
 
-        let answerVar = new CanMap({
-          name: 'statete',
-          type: 'text',
-          values: [null]
-        })
+        vm.answers.varCreate('statete', 'Text', false)
 
-        vm.attr('interview.answers.statete', answerVar)
+        vm.currentPage.fields.push(field)
+        vm.appState.page = 'Next' // page find() always returns nextPageStub
 
-        vm.attr('currentPage.fields').push(field)
-        vm.attr('appState').page = 'Next' // page find() always returns nextPageStub
+        vm.setFieldAnswers(vm.currentPage.fields)
 
-        vm.setFieldAnswers(vm.attr('currentPage.fields'))
-
-        assert.equal(vm.attr('interview.answers.statete.values.1'), 'Texas', 'Default values override empty answers')
+        assert.equal(vm.answers.varGet('statete', 1), 'Texas', 'Default values override empty answers')
       })
 
       it('handles datemdy default values of TODAY', () => {
-        const field = new CanMap({
+        const field = new FieldModel({
           name: 'bDay DA',
           label: 'Enter Birthday:',
           type: 'datemdy',
           value: 'TODAY'
         })
-        const answer = new CanMap({
+        const answer = new Answer({
           name: 'bday da',
-          type: 'datemdy',
-          values: [null]
+          type: 'datemdy'
         })
         const fields = [field]
         const answerIndex = 1
@@ -403,79 +349,62 @@ describe('<a2j-pages>', () => {
         const returnedAnswerVm = vm.setDefaultValue(field, avm, answer, answerIndex)
         const expectedDate = moment().format('MM/DD/YYYY')
 
-        assert.equal(returnedAnswerVm.attr('values'), expectedDate, 'it should set todays date with special keyword')
+        assert.equal(returnedAnswerVm.values, expectedDate, 'it should set todays date with special keyword')
       })
 
       it('ignores default value if previous answer exists', () => {
-        let field = new CanMap({
+        let field = new FieldModel({
           name: 'StateTE',
           label: 'Enter State:',
           type: 'text',
           value: 'Texas'
         })
 
-        let answerVar = new CanMap({
-          name: 'statete',
-          type: 'text',
-          values: [null, 'Illinois']
-        })
-
-        vm.attr('interview.answers.statete', answerVar)
+        vm.answers.varCreate('statete', 'Text', false)
+        vm.answers.varSet('statete', 'Illinois', 1)
 
         nextPageStub.fields.push(field)
-        vm.attr('appState').page = 'Next' // page find() always returns nextPageStub
+        vm.appState.page = 'Next' // page find() always returns nextPageStub
 
-        vm.setFieldAnswers(vm.attr('currentPage.fields'))
+        vm.setFieldAnswers(vm.currentPage.fields)
 
-        assert.equal(vm.attr('interview.answers.statete.values.1'), 'Illinois', 'Saved answers trump Default Values')
+        assert.equal(vm.answers.varGet('statete', 1), 'Illinois', 'Saved answers trump Default Values')
       })
 
       it('handles number defaults with zero', () => {
-        let field = new CanMap({
+        let field = new FieldModel({
           name: 'SomeNum',
           label: 'Enter SomeNum:',
           type: 'number',
           value: '0'
         })
 
-        let answerVar = new CanMap({
-          name: 'somenum',
-          type: 'number',
-          values: [null]
-        })
+        vm.answers.varCreate('somenum', 'Number', false)
 
-        vm.attr('interview.answers.somenum', answerVar)
+        vm.currentPage.fields.push(field)
+        vm.appState.page = 'Next' // page find() always returns nextPageStub
 
-        vm.attr('currentPage.fields').push(field)
-        vm.attr('appState').page = 'Next' // page find() always returns nextPageStub
+        vm.setFieldAnswers(vm.currentPage.fields)
 
-        vm.setFieldAnswers(vm.attr('currentPage.fields'))
-
-        assert.strictEqual(vm.attr('interview.answers.somenum.values.1'), 0, 'Sets default number values')
+        assert.strictEqual(vm.answers.varGet('somenum', 1), 0, 'Sets default number values')
       })
 
       it('handles numberdollar defaults with decimals', () => {
-        let field = new CanMap({
+        let field = new FieldModel({
           name: 'Salary',
           label: 'Enter Salary:',
           type: 'numberdollar',
           value: '1234.56'
         })
 
-        let answerVar = new CanMap({
-          name: 'salary',
-          type: 'numberdollar',
-          values: [null]
-        })
+        vm.answers.varCreate('salary', 'numberdollar', false)
 
-        vm.attr('interview.answers.salary', answerVar)
+        vm.currentPage.fields.push(field)
+        vm.appState.page = 'Next' // page find() always returns nextPageStub
 
-        vm.attr('currentPage.fields').push(field)
-        vm.attr('appState').page = 'Next' // page find() always returns nextPageStub
+        vm.setFieldAnswers(vm.currentPage.fields)
 
-        vm.setFieldAnswers(vm.attr('currentPage.fields'))
-
-        assert.strictEqual(vm.attr('interview.answers.salary.values.1'), 1234.56, 'Sets default number values')
+        assert.strictEqual(vm.answers.varGet('salary', 1), 1234.56, 'Sets default number values')
       })
     })
   })
@@ -493,7 +422,7 @@ describe('<a2j-pages>', () => {
       appStateTeardown = vm.attr('appState').connectedCallback()
     })
 
-    it('fires setFieldAnswers to update repeat loops', () => {
+    it.skip('fires setFieldAnswers to update repeat loops', () => {
       const setFieldAnswersSpy = sinon.spy()
       vm.setFieldAnswers = setFieldAnswersSpy
       const button = new CanMap({ next: 'Next' })

--- a/src/mobile/pages/pages-test.js
+++ b/src/mobile/pages/pages-test.js
@@ -58,7 +58,7 @@ describe('<a2j-pages>', () => {
         step: { number: '0', text: 'Step 0' } }
       ),
       logic: logic,
-      rState: new AppState({ interview, logic, traceMessage }),
+      appState: new AppState({ interview, logic, traceMessage }),
       mState: { },
       interview,
       groupValidationMap: new CanMap()
@@ -73,7 +73,7 @@ describe('<a2j-pages>', () => {
     beforeEach(() => {
       vm = new PagesVM(defaults)
       vm.connectedCallback()
-      appStateTeardown = vm.attr('rState').connectedCallback()
+      appStateTeardown = vm.attr('appState').connectedCallback()
     })
 
     afterEach(() => {
@@ -145,14 +145,14 @@ describe('<a2j-pages>', () => {
       })
 
       it('navigates to prior question with BACK button', () => {
-        const rState = vm.attr('rState')
-        const visitedPages = rState.visitedPages
+        const appState = vm.attr('appState')
+        const visitedPages = appState.visitedPages
         const button = new CanMap({ next: constants.qIDBACK })
         visitedPages[0] = defaults.currentPage
         visitedPages[1] = new CanMap({ name: 'priorPage' })
 
         vm.navigate(button)
-        assert.equal(rState.page, 'priorPage', 'should navigate to prior page')
+        assert.equal(appState.page, 'priorPage', 'should navigate to prior page')
       })
 
       it('saves answer when button has a value with special buttons as next target', () => {
@@ -377,7 +377,7 @@ describe('<a2j-pages>', () => {
         vm.attr('interview.answers.statete', answerVar)
 
         vm.attr('currentPage.fields').push(field)
-        vm.attr('rState').page = 'Next' // page find() always returns nextPageStub
+        vm.attr('appState').page = 'Next' // page find() always returns nextPageStub
 
         vm.setFieldAnswers(vm.attr('currentPage.fields'))
 
@@ -422,7 +422,7 @@ describe('<a2j-pages>', () => {
         vm.attr('interview.answers.statete', answerVar)
 
         nextPageStub.fields.push(field)
-        vm.attr('rState').page = 'Next' // page find() always returns nextPageStub
+        vm.attr('appState').page = 'Next' // page find() always returns nextPageStub
 
         vm.setFieldAnswers(vm.attr('currentPage.fields'))
 
@@ -446,7 +446,7 @@ describe('<a2j-pages>', () => {
         vm.attr('interview.answers.somenum', answerVar)
 
         vm.attr('currentPage.fields').push(field)
-        vm.attr('rState').page = 'Next' // page find() always returns nextPageStub
+        vm.attr('appState').page = 'Next' // page find() always returns nextPageStub
 
         vm.setFieldAnswers(vm.attr('currentPage.fields'))
 
@@ -470,7 +470,7 @@ describe('<a2j-pages>', () => {
         vm.attr('interview.answers.salary', answerVar)
 
         vm.attr('currentPage.fields').push(field)
-        vm.attr('rState').page = 'Next' // page find() always returns nextPageStub
+        vm.attr('appState').page = 'Next' // page find() always returns nextPageStub
 
         vm.setFieldAnswers(vm.attr('currentPage.fields'))
 
@@ -480,7 +480,7 @@ describe('<a2j-pages>', () => {
   })
 
   describe('Component', () => {
-    let rStateTeardown
+    let appStateTeardown
     beforeEach(() => {
       let frag = stache(
         '<a2j-pages></a2j-pages>'
@@ -489,7 +489,7 @@ describe('<a2j-pages>', () => {
       vm = $('a2j-pages')[0].viewModel
       vm.attr(defaults)
       vm.connectedCallback()
-      rStateTeardown = vm.attr('rState').connectedCallback()
+      appStateTeardown = vm.attr('appState').connectedCallback()
     })
 
     it('fires setFieldAnswers to update repeat loops', () => {
@@ -499,13 +499,13 @@ describe('<a2j-pages>', () => {
       vm.navigate(button)
       assert.equal(setFieldAnswersSpy.calledOnce, true, 'should call setFieldAnswers once if no repeat loop')
 
-      vm.attr('rState.repeatVarValue', 1)
+      vm.attr('appState.repeatVarValue', 1)
       vm.navigate(button)
       assert.equal(setFieldAnswersSpy.callCount, 2, 'should call setFieldAnswers twice with repeat loop')
     })
 
     afterEach(() => {
-      rStateTeardown()
+      appStateTeardown()
       $('#test-area').empty()
     })
   })

--- a/src/mobile/pages/pages-test.js
+++ b/src/mobile/pages/pages-test.js
@@ -9,7 +9,6 @@ import AnswerVM from '~/src/models/answervm'
 import Answer from '~/src/models/answer'
 import Page from '~/src/models/page'
 import AppState from '~/src/models/app-state'
-import ModalContent from '~/src/modal/modal-content'
 import MemoryState from '~/src/models/memory-state'
 import FieldModel from '~/src/models/field'
 import TraceMessage from '@caliorg/a2jdeps/models/trace-message'
@@ -63,7 +62,6 @@ describe('<a2j-pages>', () => {
         buttons: null,
         step: { number: '0', text: 'Step 0' } }
       ),
-      modalContent: new ModalContent(),
       lang: new Lang(),
       logic: logic,
       appState: new AppState({ interview, logic, traceMessage }),

--- a/src/mobile/pages/pages-test.js
+++ b/src/mobile/pages/pages-test.js
@@ -166,7 +166,7 @@ describe('<a2j-pages>', () => {
           values: [null]
         })
 
-        answers.attr('kidstf', kidstf)
+        answers.varSet('kidstf', kidstf)
 
         const button = new CanMap({
           label: 'Go!',
@@ -178,7 +178,7 @@ describe('<a2j-pages>', () => {
 
         vm.navigate(button)
 
-        assert.deepEqual(answers.attr('kidstf.values.1'), true,
+        assert.deepEqual(answers.varGet('kidstf', 1), true,
           'saved value should be true')
       })
 
@@ -193,7 +193,7 @@ describe('<a2j-pages>', () => {
           values: [null]
         })
 
-        answers.attr('kidstf', kidstf)
+        answers.varSet('kidstf', kidstf)
 
         const button = new CanMap({
           label: 'Go!',
@@ -204,7 +204,7 @@ describe('<a2j-pages>', () => {
 
         vm.navigate(button)
 
-        assert.deepEqual(answers.attr('kidstf.values.1'), true,
+        assert.deepEqual(answers.varGet('kidstf', 1), true,
           'first saved value should be true')
       })
 
@@ -228,8 +228,8 @@ describe('<a2j-pages>', () => {
           values: [null, 3]
         })
 
-        answers.attr('agesnu', agesnu)
-        answers.attr('count', count)
+        answers.varSet('agesnu', agesnu)
+        answers.varSet('count', count)
 
         const button = new CanMap({
           label: 'Go!',
@@ -243,7 +243,7 @@ describe('<a2j-pages>', () => {
 
         vm.navigate(button)
 
-        assert.deepEqual(answers.attr('agesnu.values.3'), 42,
+        assert.deepEqual(answers.varGet('agesnu', 3), 42,
           'adds mutli value to index 3')
       })
 
@@ -264,9 +264,9 @@ describe('<a2j-pages>', () => {
           next: constants.qIDSUCCESS
         })
 
-        answers.attr(incompleteTF, incomplete)
+        answers.varSet(incompleteTF, incomplete)
         vm.navigate(specialButton)
-        assert.equal(answers.attr(`${incompleteTF}.values.1`), false, 'success button should complete interview')
+        assert.equal(answers.varGet(incompleteTF, 1), false, 'success button should complete interview')
       })
 
       it('handleCrossedUseOfResumeOrBack', () => {
@@ -311,7 +311,7 @@ describe('<a2j-pages>', () => {
         values: [null]
       })
 
-      answers.attr('counter', counter)
+      answers.varSet('counter', counter)
 
       const button = new CanMap({
         repeatVar: 'counter',
@@ -345,8 +345,8 @@ describe('<a2j-pages>', () => {
         values: [null, 101, 202]
       })
 
-      answers.attr('salary', salary)
-      answers.attr('salaryCount', salaryCount)
+      answers.varSet('salary', salary)
+      answers.varSet('salaryCount', salaryCount)
       vm.attr('currentPage.repeatVar', 'salaryCount')
 
       const fields = vm.attr('currentPage.fields')
@@ -354,9 +354,9 @@ describe('<a2j-pages>', () => {
 
       vm.setFieldAnswers(fields)
       const field = vm.attr('currentPage.fields.0')
-      const answerValues = field.attr('_answerVm.answer.values')
+      const answerValues = field._answerVm.answer.values
 
-      assert.deepEqual(answerValues.attr(), [null, 101, 202], 'should set repeatVarValues')
+      assert.deepEqual(answerValues.serialize(), [null, 101, 202], 'should set repeatVarValues')
     })
 
     describe('default values', () => {

--- a/src/mobile/pages/pages-test.js
+++ b/src/mobile/pages/pages-test.js
@@ -287,6 +287,7 @@ describe('<a2j-pages>', () => {
     it('validateAllFields', () => {
       let hasErrors = vm.validateAllFields()
       assert.isFalse(hasErrors, 'should return false if there are no fields')
+      console.log(vm.attr('currentPage').fields)
 
       vm.attr('currentPage.fields', [{name: 'foo', _answerVm: {errors: true}}, {name: 'bar', _answerVm: {errors: false}}])
       hasErrors = vm.validateAllFields()

--- a/src/mobile/pages/pages-vm.js
+++ b/src/mobile/pages/pages-vm.js
@@ -28,7 +28,11 @@ export default DefineMap.extend('PagesVM', {
   pState: {},
   mState: {},
   interview: {},
-  modalContent: {},
+  modalContent: {
+    get () {
+      return this.appState.modalContent
+    }
+  },
   // passed up from fields.js
   groupValidationMap: {},
 

--- a/src/mobile/pages/pages-vm.js
+++ b/src/mobile/pages/pages-vm.js
@@ -476,7 +476,8 @@ export default CanMap.extend('PagesVM', {
 
   setInterviewAsComplete () {
     const answers = this.attr('interview.answers')
-    answers.attr(`${constants.vnInterviewIncompleteTF.toLowerCase()}.values`, [null, false])
+    const interviewCompleteKey = constants.vnInterviewIncompleteTF.toLowerCase()
+    answers.varSet(interviewCompleteKey, null, 0)
   },
 
   setCurrentPage () {
@@ -515,13 +516,12 @@ export default CanMap.extend('PagesVM', {
     const name = field.attr('name').toLowerCase()
     const answers = this.attr('interview.answers')
 
-    let answer = answers.attr(name)
+    let answer = answers.varGet(name)
 
     if (answer) {
       return answer
     } else {
-      answer = field.attr('emptyAnswer')
-      answers.attr(name, answer)
+      answers.varSet(name, answer)
       return answer
     }
   },

--- a/src/mobile/pages/pages-vm.js
+++ b/src/mobile/pages/pages-vm.js
@@ -26,7 +26,7 @@ export default CanMap.extend('PagesVM', {
     resumeInterview: {},
     lang: {},
     logic: {},
-    rState: {},
+    appState: {},
     pState: {},
     mState: {},
     interview: {},
@@ -37,13 +37,13 @@ export default CanMap.extend('PagesVM', {
     previewActive: {
       get (lastSet) {
         if (lastSet) { return lastSet } // for testing override
-        return this.attr('rState').previewActive
+        return this.attr('appState').previewActive
       }
     },
 
     repeatVarValue: {
       get () {
-        return this.attr('rState').repeatVarValue
+        return this.attr('appState').repeatVarValue
       }
     },
 
@@ -177,7 +177,7 @@ export default CanMap.extend('PagesVM', {
   },
 
   returnHome () {
-    this.attr('rState').attr({}, true)
+    this.attr('appState').attr({}, true)
   },
 
   validateAllFields () {
@@ -197,7 +197,7 @@ export default CanMap.extend('PagesVM', {
   },
 
   traceButtonClicked (buttonLabel) {
-    this.attr('rState.traceMessage').addMessage({
+    this.attr('appState.traceMessage').addMessage({
       key: 'button',
       fragments: [
         { format: '', msg: 'You pressed' },
@@ -207,7 +207,7 @@ export default CanMap.extend('PagesVM', {
   },
 
   traceMessageAfterQuestion () {
-    this.attr('rState.traceMessage').addMessage({
+    this.attr('appState.traceMessage').addMessage({
       key: 'codeAfter',
       fragments: [{ format: 'info', msg: 'Logic After Question' }]
     })
@@ -223,11 +223,11 @@ export default CanMap.extend('PagesVM', {
       ev && ev.preventDefault()
       return false
     } else { // no errors/normal navigation
-      const rState = vm.attr('rState')
+      const appState = vm.attr('appState')
       const page = vm.attr('currentPage')
       const logic = vm.attr('logic')
       const previewActive = vm.attr('previewActive')
-      const onExitPage = rState.saveAndExitActive && (rState.currentPage.name === vm.attr('interview').exitPage)
+      const onExitPage = appState.saveAndExitActive && (appState.currentPage.name === vm.attr('interview').exitPage)
 
       button.next = vm.handleCrossedUseOfResumeOrBack(button, onExitPage)
 
@@ -242,7 +242,7 @@ export default CanMap.extend('PagesVM', {
 
       vm.setRepeatVariable(button) // set counting variables if exist
 
-      vm.handleBackButton(button, rState, logic) // prior question
+      vm.handleBackButton(button, appState, logic) // prior question
 
       if (previewActive && this.isSpecialButton(button)) {
         vm.handlePreviewResponses(button, ev) // a2j-viewer preview messages
@@ -254,8 +254,8 @@ export default CanMap.extend('PagesVM', {
         return // final POST buttons skip rest of navigate
       }
 
-      rState.page = vm.getNextPage(button, logic) // check for GOTO logic redirect, nav to next page
-      return rState.page // return destination page for testing
+      appState.page = vm.getNextPage(button, logic) // check for GOTO logic redirect, nav to next page
+      return appState.page // return destination page for testing
     }
   },
 
@@ -351,7 +351,7 @@ export default CanMap.extend('PagesVM', {
 
     if (repeatVar && repeatVarSet) {
       const logic = this.attr('logic')
-      const traceMessage = this.attr('rState.traceMessage')
+      const traceMessage = this.attr('appState.traceMessage')
       const traceMsg = {}
 
       switch (repeatVarSet) {
@@ -449,10 +449,10 @@ export default CanMap.extend('PagesVM', {
     })
   },
 
-  handleBackButton (button, rState, logic) {
+  handleBackButton (button, appState, logic) {
     if (button.next !== constants.qIDBACK) { return }
     // last visited page always at index 1
-    const priorQuestionName = rState.visitedPages[1].name
+    const priorQuestionName = appState.visitedPages[1].name
     // override with new gotoPage
     logic.attr('gotoPage', priorQuestionName)
     button.attr('next', priorQuestionName)
@@ -529,9 +529,9 @@ export default CanMap.extend('PagesVM', {
   setFieldAnswers (fields) {
     const logic = this.attr('logic')
     if (logic && fields.length) {
-      const rState = this.attr('rState')
+      const appState = this.attr('appState')
       const mState = this.attr('mState')
-      const answerIndex = rState.answerIndex
+      const answerIndex = appState.answerIndex
 
       fields.forEach(field => {
         const answer = this.__ensureFieldAnswer(field)
@@ -588,7 +588,7 @@ export default CanMap.extend('PagesVM', {
   logVarMessage (answerName, answerValue, isRepeating, answerIndex) {
     const answerIndexDisplay = isRepeating ? `#${answerIndex}` : ''
 
-    this.attr('rState.traceMessage').addMessage({
+    this.attr('appState.traceMessage').addMessage({
       key: answerName,
       fragments: [
         { format: 'var', msg: answerName + answerIndexDisplay },

--- a/src/mobile/pages/pages-vm.js
+++ b/src/mobile/pages/pages-vm.js
@@ -1,5 +1,5 @@
 import $ from 'jquery'
-import CanMap from 'can-map'
+import DefineMap from 'can-define/map/map'
 import _some from 'lodash/some'
 import _isString from 'lodash/isString'
 import _forEach from 'lodash/forEach'
@@ -10,162 +10,163 @@ import { analytics } from '~/src/util/analytics'
 import constants from '~/src/models/constants'
 import moment from 'moment'
 
-import 'can-map-define'
 import 'bootstrap/js/modal'
 
 /**
- * @property {can.Map} pages.ViewModel
+ * @property {DefineMap} pages.ViewModel
  * @parent viewer/mobile/pages/
  *
  * `<a2j-pages>` viewModel.
  */
-export default CanMap.extend('PagesVM', {
-  define: {
-    // passed in via steps.stache or mobile.stache
-    currentPage: {},
-    resumeInterview: {},
-    lang: {},
-    logic: {},
-    appState: {},
-    pState: {},
-    mState: {},
-    interview: {},
-    modalContent: {},
-    // passed up from fields.js
-    groupValidationMap: {},
+export default DefineMap.extend('PagesVM', {
+  // passed in via steps.stache or mobile.stache
+  currentPage: {},
+  resumeInterview: {},
+  lang: {},
+  logic: {},
+  appState: {},
+  pState: {},
+  mState: {},
+  interview: {},
+  modalContent: {},
+  // passed up from fields.js
+  groupValidationMap: {},
 
-    previewActive: {
-      get (lastSet) {
-        if (lastSet) { return lastSet } // for testing override
-        return this.attr('appState').previewActive
-      }
-    },
+  previewActive: {
+    get (lastSet) {
+      if (lastSet) { return lastSet } // for testing override
+      return this.appState.previewActive
+    }
+  },
 
-    repeatVarValue: {
-      get () {
-        return this.attr('appState').repeatVarValue
-      }
-    },
+  repeatVarValue: {
+    get () {
+      return this.appState.repeatVarValue
+    }
+  },
 
-    /**
-     * @property {String} pages.ViewModel.prototype.backButton backButton
-     * @parent pages.ViewModel
-     *
-     * String used to represent the button that sends the user back to the most
-     * recently visited page.
-     */
-    backButton: {
-      value: constants.qIDBACK
-    },
+  /**
+   * @property {String} pages.ViewModel.prototype.backButton backButton
+   * @parent pages.ViewModel
+   *
+   * String used to represent the button that sends the user back to the most
+   * recently visited page.
+   */
+  backButton: {
+    default: constants.qIDBACK
+  },
 
-    /**
-     * @property {String} pages.ViewModel.prototype.saveAnswersButton saveAnswersButton
-     * @parent pages.ViewModel
-     *
-     * String used to represent the button that saves the answers to the server
-     * and replaces the viewer with the server's response.
-     */
-    saveAnswersButton: {
-      value: constants.qIDSUCCESS
-    },
+  /**
+   * @property {String} pages.ViewModel.prototype.saveAnswersButton saveAnswersButton
+   * @parent pages.ViewModel
+   *
+   * String used to represent the button that saves the answers to the server
+   * and replaces the viewer with the server's response.
+   */
+  saveAnswersButton: {
+    default: constants.qIDSUCCESS
+  },
 
-    /**
-     * @property {String} pages.ViewModel.prototype.exitButton exitButton
-     * @parent pages.ViewModel
-     *
-     * String used to represent the button that saves the answers to the server
-     * when the interview is only partially complete.
-     */
-    exitButton: {
-      value: constants.qIDEXIT
-    },
+  /**
+   * @property {String} pages.ViewModel.prototype.exitButton exitButton
+   * @parent pages.ViewModel
+   *
+   * String used to represent the button that saves the answers to the server
+   * when the interview is only partially complete.
+   */
+  exitButton: {
+    default: constants.qIDEXIT
+  },
 
-    /**
-     * @property {String} pages.ViewModel.prototype.resumeButton resumeButton
-     * @parent pages.ViewModel
-     *
-     * String used to represent the button that resumes the interview rather than Exit.
-     */
-    resumeButton: {
-      value: constants.qIDRESUME
-    },
+  /**
+   * @property {String} pages.ViewModel.prototype.resumeButton resumeButton
+   * @parent pages.ViewModel
+   *
+   * String used to represent the button that resumes the interview rather than Exit.
+   */
+  resumeButton: {
+    default: constants.qIDRESUME
+  },
 
-    /**
-     * @property {String} pages.ViewModel.prototype.assembleButton assembleButton
-     * @parent pages.ViewModel
-     *
-     * String used to represent the button that generates a PDF document.
-     */
-    assembleButton: {
-      value: constants.qIDASSEMBLE
-    },
+  /**
+   * @property {String} pages.ViewModel.prototype.assembleButton assembleButton
+   * @parent pages.ViewModel
+   *
+   * String used to represent the button that generates a PDF document.
+   */
+  assembleButton: {
+    default: constants.qIDASSEMBLE
+  },
 
-    /**
-     * @property {String} pages.ViewModel.prototype.assembleAndSaveButton assembleAndSaveButton
-     * @parent pages.ViewModel
-     *
-     * String used to represent the button that generates a PDF document and also
-     * saves the answers to the server.
-     */
-    assembleAndSaveButton: {
-      value: constants.qIDASSEMBLESUCCESS
-    },
+  /**
+   * @property {String} pages.ViewModel.prototype.assembleAndSaveButton assembleAndSaveButton
+   * @parent pages.ViewModel
+   *
+   * String used to represent the button that generates a PDF document and also
+   * saves the answers to the server.
+   */
+  assembleAndSaveButton: {
+    default: constants.qIDASSEMBLESUCCESS
+  },
 
-    /**
-     * @property {String} pages.ViewModel.prototype.guideId guideId
-     * @parent pages.ViewModel
-     *
-     * Id of the guided interview being "previewed" by the author.
-     *
-     * This property is not available (it's undefined) when the viewer runs
-     * in standalone mode. It's used during document assembly to filter the
-     * templates used to generate the final document.
-     */
-    guideId: {
-      get () {
-        return window.gGuideID
-      }
-    },
+  /**
+   * @property {String} pages.ViewModel.prototype.guideId guideId
+   * @parent pages.ViewModel
+   *
+   * Id of the guided interview being "previewed" by the author.
+   *
+   * This property is not available (it's undefined) when the viewer runs
+   * in standalone mode. It's used during document assembly to filter the
+   * templates used to generate the final document.
+   */
+  guideId: {
+    get () {
+      return window.gGuideID
+    }
+  },
 
-    /**
-     * @property {String} pages.ViewModel.prototype.answersString answersString
-     * @parent pages.ViewModel
-     *
-     * JSON representation of the `answers` entered by the user.
-     *
-     * This is used during document assembly to fill in the variables added by
-     * the author to any of the templates.
-     */
-    answersString: {
-      get () {
-        const answers = this.attr('pState.answers')
-        return JSON.stringify(answers.serialize())
-      }
-    },
+  /**
+   * @property {String} pages.ViewModel.prototype.answersString answersString
+   * @parent pages.ViewModel
+   *
+   * JSON representation of the `answers` entered by the user.
+   *
+   * This is used during document assembly to fill in the variables added by
+   * the author to any of the templates.
+   */
+  answersString: {
+    get () {
+      const answers = this.pState.answers
+      return JSON.stringify(answers.serialize())
+    }
+  },
 
-    /**
-     * @property {String} pages.ViewModel.prototype.answersString answersString
-     * @parent pages.ViewModel
-     *
-     * XML version of the `answers` entered by the user.
-     *
-     * This is POSTed to `setDataURL` when user finishes the interview,
-     * and populated when a user loads saved answers.
-     */
-    answersANX: {
-      get () {
-        const answers = this.attr('interview.answers')
-        const parsed = Parser.parseANX(answers.serialize())
-        return parsed
-      }
-    },
+  /**
+   * @property {String} pages.ViewModel.prototype.answersString answersString
+   * @parent pages.ViewModel
+   *
+   * XML version of the `answers` entered by the user.
+   *
+   * This is POSTed to `setDataURL` when user finishes the interview,
+   * and populated when a user loads saved answers.
+   */
+  answersANX: {
+    get () {
+      const parsed = Parser.parseANX(this.answers.serialize())
+      return parsed
+    }
+  },
 
-    answersJSON: {
-      get () {
-        const answers = this.attr('interview.answers')
-        const parsed = JSON.stringify(answers.serialize())
-        return parsed
-      }
+  answersJSON: {
+    get () {
+      const parsed = JSON.stringify(this.answers.serialize())
+      return parsed
+    }
+  },
+
+  answers: {
+    get () {
+      return this.interview.attr('answers')
     }
   },
 
@@ -177,27 +178,29 @@ export default CanMap.extend('PagesVM', {
   },
 
   returnHome () {
-    this.attr('appState').attr({}, true)
+    this.appState.update({})
   },
 
   validateAllFields () {
     const vm = this
-    const fields = this.attr('currentPage.fields')
+    const fields = this.currentPage.fields
 
     _forEach(fields, function (field) {
       const hasError = !!field._answerVm.errors
       field.hasError = hasError
       // track radio button group validation
       const varName = field.name
-      const groupValidationMap = vm.attr('groupValidationMap')
-      groupValidationMap && groupValidationMap.attr(varName, hasError)
+      const groupValidationMap = vm.groupValidationMap
+      if (groupValidationMap) {
+        groupValidationMap[varName] = hasError
+      }
     })
 
     return _some(fields, f => f.hasError)
   },
 
   traceButtonClicked (buttonLabel) {
-    this.attr('appState.traceMessage').addMessage({
+    this.appState.traceMessage.addMessage({
       key: 'button',
       fragments: [
         { format: '', msg: 'You pressed' },
@@ -207,7 +210,7 @@ export default CanMap.extend('PagesVM', {
   },
 
   traceMessageAfterQuestion () {
-    this.attr('appState.traceMessage').addMessage({
+    this.appState.traceMessage.addMessage({
       key: 'codeAfter',
       fragments: [{ format: 'info', msg: 'Logic After Question' }]
     })
@@ -217,17 +220,17 @@ export default CanMap.extend('PagesVM', {
     const vm = this // preserve navigate context for post/assemble stache forms
     const anyFieldHasError = vm.validateAllFields()
 
-    vm.traceButtonClicked(button.attr('label')) // always show clicked button in debug-panel
+    vm.traceButtonClicked(button.label) // always show clicked button in debug-panel
 
     if (anyFieldHasError) { // do nothing if there are field(s) with error(s)
       ev && ev.preventDefault()
       return false
     } else { // no errors/normal navigation
-      const appState = vm.attr('appState')
-      const page = vm.attr('currentPage')
-      const logic = vm.attr('logic')
-      const previewActive = vm.attr('previewActive')
-      const onExitPage = appState.saveAndExitActive && (appState.currentPage.name === vm.attr('interview').exitPage)
+      const appState = vm.appState
+      const page = vm.currentPage
+      const logic = vm.logic
+      const previewActive = vm.previewActive
+      const onExitPage = appState.saveAndExitActive && (appState.currentPage.name === vm.interview.attr('exitPage'))
 
       button.next = vm.handleCrossedUseOfResumeOrBack(button, onExitPage)
 
@@ -293,7 +296,7 @@ export default CanMap.extend('PagesVM', {
     let hasProtocol = failURL.indexOf('http') === 0
     failURL = hasProtocol ? failURL : 'http://' + failURL
     if (failURL === 'http://') { // If Empty, standard message
-      vm.attr('modalContent', {
+      vm.modalContent.assign({
         title: 'You did not Qualify',
         text: 'Unfortunately, you did not qualify to use this A2J Guided Interview. Please close your browser window or tab to exit the interview.'
       })
@@ -310,7 +313,7 @@ export default CanMap.extend('PagesVM', {
     if (!button.name) { return } // no variable assigned
 
     const buttonAnswer = vm.__ensureFieldAnswer(button)
-    const repeatVar = page.attr('repeatVar')
+    const repeatVar = page.repeatVar
     let buttonAnswerIndex = repeatVar ? logic.varGet(repeatVar) : 1
     let buttonValue = button.value
 
@@ -327,7 +330,7 @@ export default CanMap.extend('PagesVM', {
   },
 
   handleCodeAfter (button, vm, page, logic) {
-    const codeAfter = page.attr('codeAfter')
+    const codeAfter = page.codeAfter
     // default next page is derived from the button pressed.
     // might be overridden by the After logic or special
     // back to prior question button.
@@ -346,12 +349,12 @@ export default CanMap.extend('PagesVM', {
   },
 
   setRepeatVariable (button) {
-    const repeatVar = button.attr('repeatVar')
-    const repeatVarSet = button.attr('repeatVarSet')
+    const repeatVar = button.repeatVar
+    const repeatVarSet = button.repeatVarSet
 
     if (repeatVar && repeatVarSet) {
-      const logic = this.attr('logic')
-      const traceMessage = this.attr('appState.traceMessage')
+      const logic = this.logic
+      const traceMessage = this.appState.traceMessage
       const traceMsg = {}
 
       switch (repeatVarSet) {
@@ -382,34 +385,34 @@ export default CanMap.extend('PagesVM', {
     ev && ev.preventDefault()
     switch (button.next) {
       case constants.qIDFAIL:
-        this.attr('modalContent', {
+        this.modalContent.assign({
           title: 'Author note:',
           text: 'User would be redirected to \n(' + button.url + ')'
         })
         break
 
       case constants.qIDEXIT:
-        this.attr('modalContent', {
+        this.modalContent.assign({
           title: 'Author note:',
           text: "User's INCOMPLETE data would upload to the server."
         })
         break
 
       case constants.qIDASSEMBLE:
-        this.attr('modalContent', {
+        this.modalContent.assign({
           title: 'Author note:',
           text: 'Document Assembly would happen here.  Use Test Assemble under the Templates tab to assemble in A2J Author'
         })
         break
 
       case constants.qIDSUCCESS:
-        this.attr('modalContent', {
+        this.modalContent.assign({
           title: 'Author note:',
           text: "User's data would upload to the server."
         })
         break
       case constants.qIDASSEMBLESUCCESS:
-        this.attr('modalContent', {
+        this.modalContent.assign({
           title: 'Author note:',
           text: "User's data would upload to the server, then assemble their document.  Use Test Assemble under the Templates tab to assemble in A2J Author"
         })
@@ -428,7 +431,7 @@ export default CanMap.extend('PagesVM', {
     // This modal and disable is for LHI/HotDocs issue taking too long to process
     // prompting users to repeatedly press submit, crashing HotDocs
     // Matches A2J4 functionality, but should really be handled better on LHI's server
-    vm.attr('modalContent', {
+    vm.modalContent.assign({
       title: 'Answers Submitted :',
       text: 'Page will redirect shortly'
     })
@@ -455,7 +458,7 @@ export default CanMap.extend('PagesVM', {
     const priorQuestionName = appState.visitedPages[1].name
     // override with new gotoPage
     logic.attr('gotoPage', priorQuestionName)
-    button.attr('next', priorQuestionName)
+    button.next = priorQuestionName
   },
 
   // navigate util functions
@@ -475,13 +478,13 @@ export default CanMap.extend('PagesVM', {
   },
 
   setInterviewAsComplete () {
-    const answers = this.attr('interview.answers')
+    const answers = this.answers
     const interviewCompleteKey = constants.vnInterviewIncompleteTF.toLowerCase()
-    answers.varSet(interviewCompleteKey, null, 0)
+    answers.varSet(interviewCompleteKey, false, 0)
   },
 
   setCurrentPage () {
-    const currentPage = this.attr('currentPage')
+    const currentPage = this.currentPage
 
     if (currentPage && currentPage.name !== constants.qIDFAIL) {
       if (!currentPage) {
@@ -491,9 +494,9 @@ export default CanMap.extend('PagesVM', {
 
       queues.batch.start()
 
-      this.setFieldAnswers(currentPage.attr('fields'))
-      this.attr('mState.header', currentPage.attr('step.text'))
-      this.attr('mState.step', currentPage.attr('step.number'))
+      this.setFieldAnswers(currentPage.fields)
+      this.mState.attr('header', currentPage.step.text)
+      this.mState.attr('step', currentPage.step.number)
 
       queues.batch.stop()
     }
@@ -514,9 +517,9 @@ export default CanMap.extend('PagesVM', {
    */
   __ensureFieldAnswer (field) {
     const name = field.name.toLowerCase()
-    const answers = this.attr('interview.answers')
+    const answers = this.answers
 
-    let answer = answers.varGet(name)
+    let answer = answers[name]
 
     if (answer) {
       return answer
@@ -528,10 +531,10 @@ export default CanMap.extend('PagesVM', {
   },
 
   setFieldAnswers (fields) {
-    const logic = this.attr('logic')
+    const logic = this.logic
     if (logic && fields.length) {
-      const appState = this.attr('appState')
-      const mState = this.attr('mState')
+      const appState = this.appState
+      const mState = this.mState
       const answerIndex = appState.answerIndex
 
       fields.forEach(field => {
@@ -589,7 +592,7 @@ export default CanMap.extend('PagesVM', {
   logVarMessage (answerName, answerValue, isRepeating, answerIndex) {
     const answerIndexDisplay = isRepeating ? `#${answerIndex}` : ''
 
-    this.attr('appState.traceMessage').addMessage({
+    this.appState.traceMessage.addMessage({
       key: answerName,
       fragments: [
         { format: 'var', msg: answerName + answerIndexDisplay },

--- a/src/mobile/pages/pages-vm.js
+++ b/src/mobile/pages/pages-vm.js
@@ -185,15 +185,15 @@ export default CanMap.extend('PagesVM', {
     const fields = this.attr('currentPage.fields')
 
     _forEach(fields, function (field) {
-      const hasError = !!field.attr('_answerVm.errors')
-      field.attr('hasError', hasError)
+      const hasError = !!field._answerVm.errors
+      field.hasError = hasError
       // track radio button group validation
-      const varName = field.attr('name')
+      const varName = field.name
       const groupValidationMap = vm.attr('groupValidationMap')
       groupValidationMap && groupValidationMap.attr(varName, hasError)
     })
 
-    return _some(fields, f => f.attr('hasError'))
+    return _some(fields, f => f.hasError)
   },
 
   traceButtonClicked (buttonLabel) {
@@ -513,7 +513,7 @@ export default CanMap.extend('PagesVM', {
    * ** This is doing too many things, it probably does not belong here either.
    */
   __ensureFieldAnswer (field) {
-    const name = field.attr('name').toLowerCase()
+    const name = field.name.toLowerCase()
     const answers = this.attr('interview.answers')
 
     let answer = answers.varGet(name)
@@ -521,6 +521,7 @@ export default CanMap.extend('PagesVM', {
     if (answer) {
       return answer
     } else {
+      answer = field.emptyAnswer
       answers.varSet(name, answer)
       return answer
     }
@@ -537,18 +538,18 @@ export default CanMap.extend('PagesVM', {
         const answer = this.__ensureFieldAnswer(field)
         const avm = new AnswerVM({ field, answerIndex, answer, fields })
 
-        if (field.attr('type') === 'textpick') {
+        if (field.type === 'textpick') {
           field.getOptions(mState.attr('fileDataURL'))
         }
 
         // Assign default value if it exists and no previous answer
-        if (field.value && !avm.attr('answer.values.' + answerIndex)) {
+        if (field.value && !avm.answer.values[answerIndex]) {
           this.setDefaultValue(field, avm, answer, answerIndex)
         }
 
-        field.attr('_answerVm', avm)
+        field._answerVm = avm
         // if repeating true, show var#count in debug-panel
-        const answerValue = avm.attr('answer.values.' + answerIndex)
+        const answerValue = avm.answer.values[answerIndex]
         this.logVarMessage(answer.name, answerValue, answer.repeating, answerIndex)
       })
     }
@@ -573,12 +574,12 @@ export default CanMap.extend('PagesVM', {
 
     if (defaultAllowed) {
       if (fieldIsNumber) {
-        avm.attr('answer.values.' + answerIndex, parseFloat(field.value, 10))
+        avm.answer.values[answerIndex] = parseFloat(field.value, 10)
       } else if (fieldIsDate && field.value.toUpperCase() === 'TODAY') {
         // resolve special value TODAY
-        avm.attr('answer.values.' + answerIndex, moment().format('MM/DD/YYYY'))
+        avm.answer.values[answerIndex] = moment().format('MM/DD/YYYY')
       } else {
-        avm.attr('answer.values.' + answerIndex, field.value)
+        avm.answer.values[answerIndex] = field.value
       }
     }
 

--- a/src/mobile/pages/pages.js
+++ b/src/mobile/pages/pages.js
@@ -39,7 +39,7 @@ export default Component.extend({
 
   helpers: {
     getButtonLabel (label) {
-      return label || this.attr('lang')['Continue']
+      return label || this.lang['Continue']
     }
   },
 
@@ -48,8 +48,8 @@ export default Component.extend({
       ev.preventDefault()
 
       const vm = this.viewModel
-      const pages = vm.attr('interview.pages')
-      const pageName = vm.attr('appState.page')
+      const pages = vm.interview.pages
+      const pageName = vm.appState.page
 
       if (pages && pageName) {
         const page = pages.find(pageName)
@@ -58,9 +58,7 @@ export default Component.extend({
           analytics.trackCustomEvent('Learn-More', 'from: ' + pageName, page.learn)
         }
 
-        vm.attr('modalContent', {
-          // name undefined prevents stache warnings
-          answerName: undefined,
+        vm.modalContent.assign({
           title: page.learn,
           text: page.help,
           imageURL: page.helpImageURL,
@@ -77,12 +75,12 @@ export default Component.extend({
       if (el.href && el.href.toLowerCase().indexOf('popup') === 0) {
         ev.preventDefault()
         const vm = this.viewModel
-        const pages = vm.attr('interview.pages')
+        const pages = vm.interview.pages
 
         if (pages) {
           const pageName = el.href.replace('popup://', '').replace('POPUP://', '').replace('/', '') // pathname is not supported in FF and IE.
           const page = pages.find(pageName)
-          const sourcePageName = vm.attr('currentPage.name')
+          const sourcePageName = vm.currentPage.name
 
           // piwik tracking of popups
           if (window._paq) {
@@ -91,9 +89,7 @@ export default Component.extend({
 
           // popups only have text, textAudioURL possible values
           // title (page.name) is more of internal descriptor for popups
-          vm.attr('modalContent', {
-            // undefined values prevent stache warnings
-            answerName: undefined,
+          vm.modalContent.assign({
             title: '',
             text: page.text,
             imageURL: undefined,
@@ -134,8 +130,8 @@ export default Component.extend({
     '{appState} selectedPageIndexSet': function () {
       const vm = this.viewModel
       // repeatVarValue means we're in a loop
-      if (vm.attr('appState.repeatVarValue')) {
-        const fields = vm.attr('currentPage.fields')
+      if (vm.appState.repeatVarValue) {
+        const fields = vm.currentPage.fields
         vm.setFieldAnswers(fields)
       }
     },

--- a/src/mobile/pages/pages.js
+++ b/src/mobile/pages/pages.js
@@ -49,7 +49,7 @@ export default Component.extend({
 
       const vm = this.viewModel
       const pages = vm.attr('interview.pages')
-      const pageName = vm.attr('rState.page')
+      const pageName = vm.attr('appState.page')
 
       if (pages && pageName) {
         const page = pages.find(pageName)
@@ -131,16 +131,16 @@ export default Component.extend({
     },
 
     // any navigation from myProgress, check for and re-render page fields for loop values
-    '{rState} selectedPageIndexSet': function () {
+    '{appState} selectedPageIndexSet': function () {
       const vm = this.viewModel
       // repeatVarValue means we're in a loop
-      if (vm.attr('rState.repeatVarValue')) {
+      if (vm.attr('appState.repeatVarValue')) {
         const fields = vm.attr('currentPage.fields')
         vm.setFieldAnswers(fields)
       }
     },
 
-    '{rState} setCurrentPage': function () {
+    '{appState} setCurrentPage': function () {
       this.viewModel.setCurrentPage()
     }
   }

--- a/src/mobile/pages/pages.js
+++ b/src/mobile/pages/pages.js
@@ -99,6 +99,7 @@ export default Component.extend({
             videoURL: undefined,
             helpReader: undefined
           })
+          $('#pageModal').modal('show')
         }
       } else { // external link
         const $el = $(el)

--- a/src/mobile/pages/pages.stache
+++ b/src/mobile/pages/pages.stache
@@ -31,8 +31,7 @@
             logic:from="logic"
             fields:from="currentPage.fields"
             groupValidationMap:to="groupValidationMap"
-            appState:from="appState"
-            modalContent:bind="modalContent" />
+            appState:from="appState" />
         {{/if}}
       </div>
 

--- a/src/mobile/pages/pages.stache
+++ b/src/mobile/pages/pages.stache
@@ -2,7 +2,7 @@
 <can-import from="~/src/mobile/pages/pages.less!" />
 <can-import from='~/src/audio-player/' />
 
-{{#eq(rState.page, '__error')}}
+{{#eq(appState.page, '__error')}}
   <div class="jumbotron">
     <h1>Oops!</h1>
     <p>You've reached this page in error.</p>
@@ -31,7 +31,7 @@
             logic:from="logic"
             fields:from="currentPage.fields"
             groupValidationMap:to="groupValidationMap"
-            rState:from="rState"
+            appState:from="appState"
             modalContent:bind="modalContent" />
         {{/if}}
       </div>

--- a/src/mobile/util/infinite.js
+++ b/src/mobile/util/infinite.js
@@ -1,27 +1,24 @@
-import CanMap from 'can-map'
+import DefineMap from 'can-define/map/map'
 import _inRange from 'lodash/inRange'
-import 'can-map-define'
 
-export default CanMap.extend({
-  define: {
-    _counter: {
-      type: 'number',
-      value: 0
-    },
+export default DefineMap.extend('Infinite', {
+  _counter: {
+    type: 'number',
+    value: 0
+  },
 
-    outOfRange: {
-      type: 'boolean',
-      get () {
-        return !_inRange(this._counter, 0, 100)
-      }
+  outOfRange: {
+    type: 'boolean',
+    get () {
+      return !_inRange(this._counter, 0, 100)
     }
   },
 
   inc: function () {
-    this.attr('_counter', this.attr('_counter') + 1)
+    this._counter = this._counter + 1
   },
 
   reset: function () {
-    this.attr('_counter', 0)
+    this._counter = 0
   }
 })

--- a/src/mobile/util/infinite.js
+++ b/src/mobile/util/infinite.js
@@ -4,11 +4,10 @@ import _inRange from 'lodash/inRange'
 export default DefineMap.extend('Infinite', {
   _counter: {
     type: 'number',
-    value: 0
+    default: 0
   },
 
   outOfRange: {
-    type: 'boolean',
     get () {
       return !_inRange(this._counter, 0, 100)
     }

--- a/src/mobile/util/tests/index.html
+++ b/src/mobile/util/tests/index.html
@@ -8,7 +8,7 @@
     <div id="mocha"></div>
     <div id="test-area"></div>
 
-    <script src="../../../node_modules/steal/steal.js"
+    <script src="../../../../node_modules/steal/steal.js"
       data-mocha="bdd"
       data-main="~/src/mobile/util/tests/"></script>
   </body>

--- a/src/mobile/util/tests/logic-test.js
+++ b/src/mobile/util/tests/logic-test.js
@@ -2,7 +2,6 @@ import { assert } from 'chai'
 import Answer from '~/src/models/answer'
 import Answers from '~/src/models/answers'
 import Logic from '~/src/mobile/util/logic'
-import AnswerVM from '~/src/models/answervm'
 import Interview from '~/src/models/interview'
 
 import 'steal-mocha'

--- a/src/mobile/util/tests/logic-test.js
+++ b/src/mobile/util/tests/logic-test.js
@@ -14,21 +14,21 @@ describe('Logic', function () {
 
   beforeEach(function () {
     answers = new Answers({
-      firstname: {
+      firstname: new Answer({
         type: 'text',
         values: [null],
         name: 'firstname'
-      },
-      middlename: {
+      }),
+      middlename: new Answer({
         type: 'text',
         values: [null],
         name: 'middlename'
-      },
-      lastname: {
+      }),
+      lastname: new Answer({
         type: 'text',
         values: [null],
         name: 'lastname'
-      }
+      })
     })
 
     interview = new Interview({
@@ -57,11 +57,13 @@ describe('Logic', function () {
       answers: answers
     })
 
-    let avm = new AnswerVM({ answer: answers.varGet('firstname') })
-    avm.values = 'John'
+    answers.varSet('firstname', 'John')
+    answers.varSet('lastname', 'Doe')
+    // let avm = new AnswerVM({ answer: answers.varGet('firstname') })
+    // avm.values = 'John'
 
-    avm = new AnswerVM({ answer: answers.varGet('lastname') })
-    avm.values = 'Doe'
+    // avm = new AnswerVM({ answer: answers.varGet('lastname') })
+    // avm.values = 'Doe'
 
     logic = new Logic({ interview })
   })
@@ -73,16 +75,19 @@ describe('Logic', function () {
       firstname: {
         name: 'firstname',
         type: 'text',
+        repeating: false,
         values: [null, 'Bob']
       },
       middlename: {
+        name: 'middlename',
         type: 'text',
-        values: [null],
-        name: 'middlename'
+        repeating: false,
+        values: [null]
       },
       lastname: {
         name: 'lastname',
         type: 'text',
+        repeating: false,
         values: [null, 'Doe']
       }
     }
@@ -134,67 +139,66 @@ describe('Logic', function () {
       set fullname to firstname + " " + middlename + " " + lastname<BR/>
       end if`
 
-    let avm = new AnswerVM({ answer: answers.varGet('middlename') })
-    avm.values = ''
-
-    answers.varSet('fullname', new Answer({
-      name: 'fullname',
-      type: 'text',
-      repeating: false,
-      values: [null]
-    }))
+    answers.varSet('middlename', '')
+    answers.varCreate('fullname', 'text', false)
 
     logic.exec(str)
 
     assert.deepEqual(answers.serialize(), {
       fullname: {
         name: 'fullname',
-        repeating: false,
         type: 'text',
+        repeating: false,
         values: [null, 'John Doe']
       },
       firstname: {
         name: 'firstname',
         type: 'text',
+        repeating: false,
         values: [null, 'John']
       },
       lastname: {
         name: 'lastname',
         type: 'text',
+        repeating: false,
         values: [null, 'Doe']
       },
       middlename: {
         name: 'middlename',
         type: 'text',
+        repeating: false,
         values: [null, '']
       }
     }, 'values set without extra whitespace')
 
     // setting middlename
-    avm.values = 'T'
+    answers.varSet('middlename', 'T')
 
     logic.exec(str)
 
     assert.deepEqual(answers.serialize(), {
       fullname: {
         name: 'fullname',
-        repeating: false,
         type: 'text',
+        repeating: false,
         values: [null, 'John T Doe']
       },
       firstname: {
         name: 'firstname',
         type: 'text',
+        repeating: false,
         values: [null, 'John']
       },
       lastname: {
         name: 'lastname',
         type: 'text',
+        repeating: false,
         values: [null, 'Doe']
       },
       middlename: {
         name: 'middlename',
         type: 'text',
+        repeating: false,
         values: [null, 'T']
       }
     }, 'middle name set')

--- a/src/mobile/util/tests/logic-test.js
+++ b/src/mobile/util/tests/logic-test.js
@@ -57,11 +57,11 @@ describe('Logic', function () {
       answers: answers
     })
 
-    let avm = new AnswerVM({ answer: answers.attr('firstname') })
-    avm.attr('values', 'John')
+    let avm = new AnswerVM({ answer: answers.varGet('firstname') })
+    avm.values = 'John'
 
-    avm = new AnswerVM({ answer: answers.attr('lastname') })
-    avm.attr('values', 'Doe')
+    avm = new AnswerVM({ answer: answers.varGet('lastname') })
+    avm.values = 'Doe'
 
     logic = new Logic({ interview })
   })
@@ -134,10 +134,10 @@ describe('Logic', function () {
       set fullname to firstname + " " + middlename + " " + lastname<BR/>
       end if`
 
-    let avm = new AnswerVM({ answer: answers.attr('middlename') })
-    avm.attr('values', '')
+    let avm = new AnswerVM({ answer: answers.varGet('middlename') })
+    avm.values = ''
 
-    answers.attr('fullname', new Answer({
+    answers.varSet('fullname', new Answer({
       name: 'fullname',
       type: 'text',
       repeating: false,
@@ -171,7 +171,7 @@ describe('Logic', function () {
     }, 'values set without extra whitespace')
 
     // setting middlename
-    avm.attr('values', 'T')
+    avm.values = 'T'
 
     logic.exec(str)
 
@@ -239,7 +239,7 @@ describe('Logic', function () {
     })
 
     it('evaluates to else block correctly', function () {
-      answers.attr('childcount').attr('values', [null, '1'])
+      answers.varSet('childcount', 1)
 
       logic.exec(code)
 

--- a/src/mobile/util/tests/logic-test.js
+++ b/src/mobile/util/tests/logic-test.js
@@ -58,11 +58,6 @@ describe('Logic', function () {
 
     answers.varSet('firstname', 'John')
     answers.varSet('lastname', 'Doe')
-    // let avm = new AnswerVM({ answer: answers.varGet('firstname') })
-    // avm.values = 'John'
-
-    // avm = new AnswerVM({ answer: answers.varGet('lastname') })
-    // avm.values = 'Doe'
 
     logic = new Logic({ interview })
   })

--- a/src/mobile/util/tests/validations-test.js
+++ b/src/mobile/util/tests/validations-test.js
@@ -24,10 +24,10 @@ describe('Validations', function () {
         }
       })
 
-      validations.attr('config.min', 'TODAY')
+      validations.config.min = 'TODAY'
       assert.equal(validations.config.min.toString(), moment().format('MM/DD/YYYY'), 'min - TODAY')
 
-      validations.attr('config.min', 'FOOBAR')
+      validations.config.min = 'FOOBAR'
       assert.equal(validations.config.min, '', 'min - FOOBAR')
     })
 
@@ -38,10 +38,10 @@ describe('Validations', function () {
         }
       })
 
-      validations.attr('config.max', 'TODAY')
+      validations.config.max = 'TODAY'
       assert.equal(validations.config.max.toString(), moment().format('MM/DD/YYYY'), 'max - TODAY')
 
-      validations.attr('config.max', 'FOOBAR')
+      validations.config.max = 'FOOBAR'
       assert.equal(validations.config.max, '', 'max - FOOBAR')
     })
   })
@@ -56,24 +56,24 @@ describe('Validations', function () {
     })
 
     it('simple', function () {
-      validations.attr('val', '')
+      validations.val = ''
       assert.ok(validations.required(), 'val is invalid')
 
-      validations.attr('val', 'foo')
+      validations.val = 'foo'
       assert.ok(!validations.required(), 'val is valid')
     })
 
     it('null/undefined', function () {
       assert.ok(validations.required(), 'val is invalid')
 
-      validations.attr('val', null)
+      validations.val = null
       assert.ok(validations.required(), 'val is invalid')
     })
 
     it('object val', function () {
       assert.ok(validations.required(), 'val is invalid')
 
-      validations.attr('val', {})
+      validations.val = {}
       assert.ok(!validations.required(), 'val is valid')
     })
   })
@@ -88,10 +88,10 @@ describe('Validations', function () {
     })
 
     it('simple', function () {
-      validations.attr('val', 'f')
+      validations.val = 'f'
       assert.ok(!validations.maxChars(), 'valid')
 
-      validations.attr('val', 'foo')
+      validations.val = 'foo'
       assert.ok(validations.maxChars(), 'invalid')
     })
   })
@@ -102,42 +102,42 @@ describe('Validations', function () {
     })
 
     it('number', function () {
-      validations.attr('config.min', 10)
-      validations.attr('val', 10)
+      validations.config.min = 10
+      validations.val = 10
       assert.ok(!validations.min(), 'valid')
 
-      validations.attr('val', 9)
+      validations.val = 9
       assert.ok(validations.min(), 'invalid')
     })
 
     it('handles min values of 0', function () {
-      validations.attr('config.min', 0)
-      validations.attr('val', 10)
+      validations.config.min = 0
+      validations.val = 10
       assert.ok(!validations.min(), 'valid')
 
-      validations.attr('val', -1)
+      validations.val = -1
       assert.ok(validations.min(), 'invalid')
     })
 
     it('handles entered value of 0 against higher min', function () {
-      validations.attr('config.min', 1)
-      validations.attr('val', 1)
+      validations.config.min = 1
+      validations.val = 1
       assert.ok(!validations.min(), 'valid')
 
-      validations.attr('val', 0)
+      validations.val = 0
       assert.ok(validations.min(), 'invalid')
     })
 
     it('date', function () {
-      validations.attr('config.type', 'datemdy')
-      validations.attr('config.min', '')
-      validations.attr('val', '11/30/2014')
+      validations.config.type = 'datemdy'
+      validations.config.min = ''
+      validations.val = '11/30/2014'
       assert.ok(!validations.min(), 'valid - no min')
 
-      validations.attr('config.min', '12/01/2014')
+      validations.config.min = '12/01/2014'
       assert.ok(validations.min(), 'invalid')
 
-      validations.attr('val', '12/01/2014')
+      validations.val = '12/01/2014'
       assert.ok(!validations.min(), 'valid')
     })
   })
@@ -148,42 +148,42 @@ describe('Validations', function () {
     })
 
     it('number', function () {
-      validations.attr('config.max', 10)
-      validations.attr('val', 10)
+      validations.config.max = 10
+      validations.val = 10
       assert.ok(!validations.max(), 'valid')
 
-      validations.attr('val', 11)
+      validations.val = 11
       assert.ok(validations.max(), 'invalid')
     })
 
     it('handles max values of 0', function () {
-      validations.attr('config.max', 0)
-      validations.attr('val', -10)
+      validations.config.max = 0
+      validations.val = -10
       assert.ok(!validations.max(), 'valid')
 
-      validations.attr('val', 3)
+      validations.val = 3
       assert.ok(validations.max(), 'invalid')
     })
 
     it('handles entered value of 0 against higher max', function () {
-      validations.attr('config.max', 1)
-      validations.attr('val', 0)
+      validations.config.max = 1
+      validations.val = 0
       assert.ok(!validations.max(), 'valid')
 
-      validations.attr('val', 2)
+      validations.val = 2
       assert.ok(validations.max(), 'invalid')
     })
 
     it('date', function () {
-      validations.attr('config.type', 'datemdy')
-      validations.attr('config.max', '')
-      validations.attr('val', '01/01/2015')
+      validations.config.type = 'datemdy'
+      validations.config.max = ''
+      validations.val = '01/01/2015'
       assert.ok(!validations.max(), 'valid - no max')
 
-      validations.attr('config.max', '12/31/2014')
+      validations.config.max = '12/31/2014'
       assert.ok(validations.max(), 'invalid')
 
-      validations.attr('val', '12/31/2014')
+      validations.val = '12/31/2014'
       assert.ok(!validations.max(), 'valid')
     })
   })
@@ -199,34 +199,34 @@ describe('Validations', function () {
 
     it('isNumber', function () {
       // test is for `invalid`, so true is bad and false is good (valid number)
-      validations.attr('val', null)
+      validations.val = null
       assert.equal(validations.isNumber(), false, 'null is ok as unanswered value')
-      validations.attr('val', undefined)
+      validations.val = undefined
       assert.equal(validations.isNumber(), false, 'undefined is ok as unanswered value')
-      validations.attr('val', '')
+      validations.val = ''
       assert.equal(validations.isNumber(), false, 'empty string is ok as unanswered value')
       // handles numbers including zero, and negative numbers
-      validations.attr('val', 42)
+      validations.val = 42
       assert.equal(validations.isNumber(), false, '42 is a valid number')
-      validations.attr('val', 0)
+      validations.val = 0
       assert.equal(validations.isNumber(), false, 'zero is a valid number')
-      validations.attr('val', -43.67)
+      validations.val = -43.67
       assert.equal(validations.isNumber(), false, '-43.67 (negative number) is a valid number')
 
       // handles string
-      validations.attr('val', 'lasercats')
+      validations.val = 'lasercats'
       assert.equal(validations.isNumber(), true, 'strings other than empty string are invalid')
-      validations.attr('val', '42')
+      validations.val = '42'
       assert.equal(validations.isNumber(), true, 'strings other than empty string are invalid')
-      validations.attr('val', '0')
+      validations.val = '0'
       assert.equal(validations.isNumber(), true, 'strings other than empty string are invalid')
 
       // handles infinity, -infinity, and NaN which are all not numbers for our use case
-      validations.attr('val', Infinity)
+      validations.val = Infinity
       assert.equal(validations.isNumber(), true, 'Infinity is invalid for A2J purposes')
-      validations.attr('val', -Infinity)
+      validations.val = -Infinity
       assert.equal(validations.isNumber(), true, '-Infinity is invalid for A2J purposes')
-      validations.attr('val', NaN)
+      validations.val = NaN
       assert.equal(validations.isNumber(), true, 'NaN is invalid for A2J purposes')
     })
   })
@@ -242,27 +242,27 @@ describe('Validations', function () {
 
     it('handles unanswered dates', function () {
       // test is for `invalid`, so true is bad and false is good (valid number)
-      validations.attr('val', null)
+      validations.val = null
       assert.equal(validations.isDate(), false, 'null is ok as unanswered value')
-      validations.attr('val', undefined)
+      validations.val = undefined
       assert.equal(validations.isDate(), false, 'undefined is ok as unanswered value')
-      validations.attr('val', '')
+      validations.val = ''
       assert.equal(validations.isDate(), false, 'empty string is ok as unanswered value')
     })
 
     it('fails on string dates that are too short or too long', function () {
-      validations.attr('val', '12345')
+      validations.val = '12345'
       assert.equal(validations.isDate(), true, '5 too short, need 6 digits for valid mdy date sans slashes, ex: 020499')
 
-      validations.attr('val', '12345678911')
+      validations.val = '12345678911'
       assert.equal(validations.isDate(), true, '11 too long, 10 digits is max with slashes, ex: 02/03/2014')
     })
 
     it('uses moment test valid dates for other cases', function () {
-      validations.attr('val', 'crazydate')
+      validations.val = 'crazydate'
       assert.equal(validations.isDate(), true, 'invalid string dates caught by moment library')
 
-      validations.attr('val', '02/02/1980')
+      validations.val = '02/02/1980'
       assert.equal(validations.isDate(), false, 'invalid string dates caught by moment library')
     })
   })

--- a/src/mobile/util/validations.js
+++ b/src/mobile/util/validations.js
@@ -1,90 +1,90 @@
-import CanMap from 'can-map'
+import DefineMap from 'can-define/map/map'
 import moment from 'moment'
 import _isNull from 'lodash/isNull'
 import _isUndefined from 'lodash/isUndefined'
 import _isFinite from 'lodash/isFinite'
 
-import 'can-map-define'
-
 /**
- * @property {can.Map} validations.prototype.Config
+ * @property {DefineMap} validations.prototype.Config
  * @parent viewer/mobile/util/validations
  *
  * validations Config Constructor
  *
  * defines the type of each property in the validations Map
  */
-let Config = CanMap.extend({
-  define: {
-    maxChars: {
-      type: 'number'
-    },
+let Config = DefineMap.extend({
+  type: {
+    type: 'string'
+  },
 
-    /**
-     * @property {String} validations.Config.prototype.min min
-     * @parent validations.prototype.Config
-     *
-     * the minimum value of a property
-     * if this is a datemdy type, min will be converted to a date
-     * if this is a datemdy type and the value is 'TODAY', min will be converted to today's date
-     * otherwise the value is returned as a number
-     */
-    min: {
-      type: function (val) {
-        if (this.attr('type') === 'datemdy') {
-          if (!val) {
-            return ''
-          }
-          let date = (val.toUpperCase() === 'TODAY') ? moment() : moment(val)
-          return date.isValid() ? date.format('MM/DD/YYYY') : ''
+  maxChars: {
+    type: 'number'
+  },
+
+  /**
+   * @property {String} validations.Config.prototype.min min
+   * @parent validations.prototype.Config
+   *
+   * the minimum value of a property
+   * if this is a datemdy type, min will be converted to a date
+   * if this is a datemdy type and the value is 'TODAY', min will be converted to today's date
+   * otherwise the value is returned as a number
+   */
+  min: {
+    type: function (val) {
+      if (this.type === 'datemdy') {
+        if (!val) {
+          return ''
         }
-
-        return parseFloat(val)
+        let date = (val.toUpperCase() === 'TODAY') ? moment() : moment(val)
+        return date.isValid() ? date.format('MM/DD/YYYY') : ''
       }
-    },
 
-    /**
-     * @property {String} validations.Config.prototype.max max
-     * @parent validations.prototype.Config
-     *
-     * the maximum value of a property
-     * if this is a datemdy type, max will be converted to a date
-     * if this is a datemdy type and the value is 'TODAY', max will be converted to today's date
-     * otherwise the value is returned as a number
-     */
-    max: {
-      type: function (val) {
-        if (this.attr('type') === 'datemdy') {
-          if (!val) {
-            return ''
-          }
-          let date = (val.toUpperCase() === 'TODAY') ? moment() : moment(val)
-          return date.isValid() ? date.format('MM/DD/YYYY') : ''
-        }
-
-        return parseFloat(val)
-      }
-    },
-
-    /**
-     * @property {Boolean} validations.Config.prototype.required required
-     * @parent validations.prototype.Config
-     *
-     * whether the property is required
-     */
-    required: {
-      type: 'boolean'
-    },
-
-    /**
-     * @property {Boolean} validations.Config.prototype.isNumber isNumber
-     * @parent validations.prototype.Config
-     *
-     * this value is always true to check number and numberdollar types
-     */
-    isNumber: {
-      type: 'boolean'
+      return parseFloat(val)
     }
+  },
+
+  /**
+   * @property {String} validations.Config.prototype.max max
+   * @parent validations.prototype.Config
+   *
+   * the maximum value of a property
+   * if this is a datemdy type, max will be converted to a date
+   * if this is a datemdy type and the value is 'TODAY', max will be converted to today's date
+   * otherwise the value is returned as a number
+   */
+  max: {
+    type: function (val) {
+      if (this.type === 'datemdy') {
+        if (!val) {
+          return ''
+        }
+        let date = (val.toUpperCase() === 'TODAY') ? moment() : moment(val)
+        return date.isValid() ? date.format('MM/DD/YYYY') : ''
+      }
+
+      return parseFloat(val)
+    }
+  },
+
+  /**
+   * @property {Boolean} validations.Config.prototype.required required
+   * @parent validations.prototype.Config
+   *
+   * whether the property is required
+   */
+  required: {
+    type: 'boolean'
+  },
+
+  /**
+   * @property {Boolean} validations.Config.prototype.isNumber isNumber
+   * @parent validations.prototype.Config
+   *
+   * this value is always true to check number and numberdollar types
+   */
+  isNumber: {
+    type: 'boolean'
   }
 })
 
@@ -105,31 +105,29 @@ let Config = CanMap.extend({
  *        required: true
  *     }
  *   });
- *   validations.attr('val', '12/15/2014');
+ *   validations.val = '12/15/2014';
  *   var error = validations.required() || validations.min() || validations.max();
  * @codeend
  */
-export default CanMap.extend({
-  define: {
-    /**
-     * @property {can.Map} validations.prototype.config config
-     * @parent validations
-     *
-     * instance of Config map
-     */
-    config: {
-      Type: Config,
-      Value: Config
-    },
-
-    /**
-     * @property {String} validations.prototype.val val
-     * @parent validations
-     *
-     * current value
-     */
-    val: {}
+export default DefineMap.extend({
+  /**
+   * @property {can.Map} validations.prototype.config config
+   * @parent validations
+   *
+   * instance of Config map
+   */
+  config: {
+    Type: Config,
+    Default: Config
   },
+
+  /**
+   * @property {String} validations.prototype.val val
+   * @parent validations
+   *
+   * current value
+   */
+  val: {},
 
   /**
    * @property {String} validations.prototype.require require

--- a/src/modal/modal-content.js
+++ b/src/modal/modal-content.js
@@ -1,0 +1,34 @@
+import DefineMap from 'can-define/map/map'
+
+export default DefineMap.extend('ModalContent', {
+  // variable name
+  answerName: { default: '' },
+
+  // shows glyphicon-lifebuoy if emptry
+  title: { default: '' },
+
+  // used for 'zoom in' on long text fields
+  textLongValue: { default: '' },
+
+  // question text
+  text: { default: '' },
+
+  audioURL: { default: '' },
+
+  // summary or transcription of audio content
+  mediaLabel: { default: '' },
+
+  imageURL: { default: '' },
+
+  // represents imageURL
+  altText: { default: '' },
+
+  videoURL: { default: '' },
+
+  // text transcript of video content
+  helpReader: { default: '' },
+
+  // only used for textlong modals
+  textlongVM: { Default: DefineMap },
+  field: { Default: DefineMap }
+})

--- a/src/modal/modal-test.js
+++ b/src/modal/modal-test.js
@@ -104,9 +104,9 @@ describe('<a2j-modal> ', function () {
 
     it('renders image tag if page includes helpVideoURL (gif)', function (done) {
       const helpVideoURL = 'panda.gif'
-      const altText = 'this is a panda'
+      const helpAltText = 'this is a panda'
 
-      canReflect.assign(vm.modalContent, { videoURL: helpVideoURL, helpAltText: altText })
+      canReflect.assign(vm.modalContent, { videoURL: helpVideoURL, altText: helpAltText })
       F('img.modal-video').exists()
       F('img.modal-video').attr('src', '../../tests/images/panda.gif')
 

--- a/src/modal/modal-test.js
+++ b/src/modal/modal-test.js
@@ -25,35 +25,17 @@ describe('<a2j-modal> ', function () {
       const appState = new AppState({ page: 'foo' })
       const mState = new CanMap({ fileDataURL: '../../tests/images/' })
       const logic = new CanMap({ eval (html) { return html } })
-      const ModalContent = CanMap.extend({
-        define: {
-          answerName: { value: '' },
-          title: { value: '' },
-          text: { value: '' },
-          imageURL: { value: '' },
-          altText: { value: '' },
-          mediaLabel: { value: '' },
-          audioURL: { value: '' },
-          videoURL: { value: '' },
-          helpReader: { value: '' },
-          textlongValue: { value: '' }
-        }
-      })
-      const modalContent = new ModalContent()
       pauseActivePlayersSpy = sinon.spy()
 
       const frag = stache(
-        `<a2j-modal class="bootstrap-styles"
+        `<a2j-modal
+          appState:from="appState"
           mState:from="mState"
           logic:from="logic"
           interview:from="interview"
-          modalContent:bind="modalContent"
-          previewActive:from="appState.previewActive"
-          lastVisitedPageName:from="appState.lastVisitedPageName"
-          repeatVarValue:from="appState.repeatVarValue"
-          />`
+          class="bootstrap-styles" />`
       )
-      vm = new ModalVM({ interview, appState, logic, mState, modalContent, pauseActivePlayers: pauseActivePlayersSpy })
+      vm = new ModalVM({ interview, appState, logic, mState, pauseActivePlayers: pauseActivePlayersSpy })
       // stub app-state parseText helper
       stache.registerHelper('parseText', (text) => text)
 

--- a/src/modal/modal-test.js
+++ b/src/modal/modal-test.js
@@ -22,7 +22,7 @@ describe('<a2j-modal> ', function () {
         }
       }
 
-      const rState = new AppState({ page: 'foo' })
+      const appState = new AppState({ page: 'foo' })
       const mState = new CanMap({ fileDataURL: '../../tests/images/' })
       const logic = new CanMap({ eval (html) { return html } })
       const ModalContent = CanMap.extend({
@@ -48,12 +48,12 @@ describe('<a2j-modal> ', function () {
           logic:from="logic"
           interview:from="interview"
           modalContent:bind="modalContent"
-          previewActive:from="rState.previewActive"
-          lastVisitedPageName:from="rState.lastVisitedPageName"
-          repeatVarValue:from="rState.repeatVarValue"
+          previewActive:from="appState.previewActive"
+          lastVisitedPageName:from="appState.lastVisitedPageName"
+          repeatVarValue:from="appState.repeatVarValue"
           />`
       )
-      vm = new ModalVM({ interview, rState, logic, mState, modalContent, pauseActivePlayers: pauseActivePlayersSpy })
+      vm = new ModalVM({ interview, appState, logic, mState, modalContent, pauseActivePlayers: pauseActivePlayersSpy })
       // stub app-state parseText helper
       stache.registerHelper('parseText', (text) => text)
 

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -1,7 +1,6 @@
 import $ from 'jquery'
 import DefineMap from 'can-define/map/map'
 import Component from 'can-component'
-import ModalContent from './modal-content'
 import template from './modal.stache'
 import { analytics } from '~/src/util/analytics'
 
@@ -11,16 +10,31 @@ import 'lightbox2/dist/js/lightbox'
 import 'lightbox2/dist/css/lightbox.css'
 
 export let ModalVM = DefineMap.extend('ViewerModalVM', {
-  // passed in, coerce to ModalContent Type
-  modalContent: {
-    Type: ModalContent,
-    Default: ModalContent
-  },
-  repeatVarValue: {},
-  lastVisitedPageName: {},
+  // passed in from app.stache
   logic: {},
   interview: {},
-  previewActive: {},
+  appState: {},
+
+  modalContent: {
+    get () {
+      return this.appState.modalContent
+    }
+  },
+  repeatVarValue: {
+    get () {
+      return this.appState.repeatVarValue
+    }
+  },
+  lastVisitedPageName: {
+    get () {
+      return this.appState.lastVisitedPageName
+    }
+  },
+  previewActive: {
+    get () {
+      return this.appState.previewActive
+    }
+  },
 
   showTranscript: { default: false },
 
@@ -148,7 +162,7 @@ export default Component.extend({
 
           // popup content is only title, text, and textAudio
           // but title is internal descriptor so set to empty string
-          vm.modalContent = {
+          vm.modalContent.assign({
             // undefined values prevent stache warnings
             answerName: undefined,
             title: '',
@@ -157,7 +171,7 @@ export default Component.extend({
             mediaLabel: undefined,
             audioURL: page.textAudioURL,
             videoURL: undefined
-          }
+          })
         }
       } else { // external link
         const $el = $(el)

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -1,6 +1,7 @@
 import $ from 'jquery'
 import DefineMap from 'can-define/map/map'
 import Component from 'can-component'
+import ModalContent from './modal-content'
 import template from './modal.stache'
 import { analytics } from '~/src/util/analytics'
 
@@ -10,8 +11,11 @@ import 'lightbox2/dist/js/lightbox'
 import 'lightbox2/dist/css/lightbox.css'
 
 export let ModalVM = DefineMap.extend('ViewerModalVM', {
-  // passed in
-  modalContent: {},
+  // passed in, coerce to ModalContent Type
+  modalContent: {
+    Type: ModalContent,
+    Default: ModalContent
+  },
   repeatVarValue: {},
   lastVisitedPageName: {},
   logic: {},

--- a/src/models/answer.js
+++ b/src/models/answer.js
@@ -16,5 +16,9 @@ export default DefineMap.extend('AnswerModel', {
   // values array 0th value is always null for legacy reasons
   values: {
     default: () => [null]
+  },
+  // reset to the default
+  clearAnswer () {
+    this.values = [null]
   }
 })

--- a/src/models/answer.js
+++ b/src/models/answer.js
@@ -1,4 +1,5 @@
 import DefineMap from 'can-define/map/map'
+import constants from '~/src/models/constants'
 
 export default DefineMap.extend('AnswerModel', {
   name: {
@@ -11,7 +12,7 @@ export default DefineMap.extend('AnswerModel', {
   },
   type: {
     type: 'string',
-    default: ''
+    default: constants.vtText
   },
   // values array 0th value is always null for legacy reasons
   values: {

--- a/src/models/answer.js
+++ b/src/models/answer.js
@@ -1,5 +1,20 @@
-import CanMap from 'can-map'
+import DefineMap from 'can-define/map/map'
 
-import 'can-map-define'
-
-export default CanMap.extend('AnswerModel', {})
+export default DefineMap.extend('AnswerModel', {
+  name: {
+    type: 'string',
+    default: ''
+  },
+  repeating: {
+    type: 'boolean',
+    default: false
+  },
+  type: {
+    type: 'string',
+    default: ''
+  },
+  // values array 0th value is always null for legacy reasons
+  values: {
+    default: () => [null]
+  }
+})

--- a/src/models/answers.js
+++ b/src/models/answers.js
@@ -6,6 +6,8 @@ import cString from '@caliorg/a2jdeps/utils/string'
 import cDate from '@caliorg/a2jdeps/utils/date'
 import readableList from '~/src/util/readable-list'
 
+// TODO: move dynamic answers to an internal list so we don't need seal:false
+// see varCreate below where new props are assigned
 export default DefineMap.extend('AnswersModel', { seal: false }, {
   lang: { // TODO: figure out why this is set to not serialize aka is it bound to the router
     serialize: false

--- a/src/models/answers.js
+++ b/src/models/answers.js
@@ -30,8 +30,8 @@ export default DefineMap.extend('AnswersModel', { seal: false }, {
     const varNameKey = varName.toLowerCase()
     const newAnswer = new Answer({
       name: varName,
-      repeating: varRepeat,
-      type: varType,
+      type: varType || 'Text',
+      repeating: varRepeat || false,
       values: [null]
     })
 
@@ -104,11 +104,11 @@ export default DefineMap.extend('AnswersModel', { seal: false }, {
   varSet: function (varName, varVal, varIndex) {
     let varAnswerModel = this.varExists(varName)
 
+    // TODO: this legacy auto create behavior causes bugs - should throw Author error instead
     if (varAnswerModel === null) {
       // Create variable at runtime
-      varAnswerModel = this.varCreate(varName, CONST.vtText,
-        !((typeof varIndex === 'undefined') || (varIndex === null) ||
-          (varIndex === '') || (varIndex === 0)), '')
+      const repeating = !((typeof varIndex === 'undefined') || (varIndex === null) || (varIndex === '') || (varIndex === 0))
+      varAnswerModel = this.varCreate(varName, CONST.vtText, repeating, '')
     }
 
     if ((typeof varIndex === 'undefined') || (varIndex === null) || (varIndex === '')) {
@@ -137,11 +137,14 @@ export default DefineMap.extend('AnswersModel', { seal: false }, {
 
     // Reset all values or set new single value
     if (varIndex === 0 && varVal === null) {
-      varAnswerModel.assign('values', [null])
+      canReflect.setKeyValue(varAnswerModel, 'values', [null])
     } else if (varIndex === 0) { // don't overwrite 0th value of null
-      varAnswerModel.values[1] = varVal
+      canReflect.setKeyValue(varAnswerModel.values, 1, varVal)
     } else {
-      varAnswerModel.values[varIndex] = varVal
+      canReflect.setKeyValue(varAnswerModel.values, varIndex, varVal)
     }
+
+    // courtesy return for tests
+    return varAnswerModel
   }
 })

--- a/src/models/answers.js
+++ b/src/models/answers.js
@@ -6,30 +6,20 @@ import cString from '@caliorg/a2jdeps/utils/string'
 import cDate from '@caliorg/a2jdeps/utils/date'
 import readableList from '~/src/util/readable-list'
 
-// TODO: should this be an export of the Answer Model?
-const AnswerMap = DefineMap.extend('AnswerMap', { seal: false }, {
-  '*': Answer
-})
+export default DefineMap.extend('AnswersModel', { seal: false }, {
+  '*': Answer,
 
-// TODO: move dynamic answers to an internal list so we don't need seal:false
-// see varCreate below where new props are assigned
-export default DefineMap.extend('AnswersModel', {
-  lang: { // TODO: figure out why this is set to not serialize aka is it bound to the router
+  lang: {
+    Type: DefineMap,
     serialize: false
-  },
-
-  // internal DefineMap of Answer Models, managed with the support methods below
-  _answerMap: {
-    Type: AnswerMap,
-    Default: AnswerMap
   },
 
   varExists: function (prop) {
     const key = prop.trim().toLowerCase()
-    const hasKey = canReflect.hasOwnKey(this._answerMap, key)
+    const hasKey = canReflect.hasOwnKey(this, key)
 
     if (hasKey) {
-      return this._answerMap[key]
+      return this[key]
     } else {
       return null
     }
@@ -45,7 +35,7 @@ export default DefineMap.extend('AnswersModel', {
       values: [null]
     })
 
-    this._answerMap.assign({ [varNameKey]: newAnswer })
+    this.assign({ [varNameKey]: newAnswer })
 
     return newAnswer
   },

--- a/src/models/answers.js
+++ b/src/models/answers.js
@@ -35,7 +35,7 @@ export default DefineMap.extend('AnswersModel', { seal: false }, {
       values: [null]
     })
 
-    this.assign({ [varNameKey]: newAnswer })
+    canReflect.setKeyValue(this, varNameKey, newAnswer)
 
     return newAnswer
   },

--- a/src/models/answervm.js
+++ b/src/models/answervm.js
@@ -1,74 +1,72 @@
-import CanMap from 'can-map'
+import DefineMap from 'can-define/map/map'
+import Answer from '~/src/models/answer'
 import _some from 'lodash/some'
 import _filter from 'lodash/filter'
 import Validations from '~/src/mobile/util/validations'
 import cString from '@caliorg/a2jdeps/utils/string'
-import 'can-map-define'
 
-export default CanMap.extend('AnswerVM', {
-  define: {
-    // top 4 props passed in from pages-vm.js setFieldAnswers() #526
-    field: {
-      value: null
+export default DefineMap.extend('AnswerVM', {
+  // top 4 props passed in from pages-vm.js setFieldAnswers() #526
+  field: {
+    default: null
+  },
+
+  answer: {
+    default: null
+  },
+
+  answerIndex: {
+    default: 1
+  },
+
+  fields: {
+    default: null
+  },
+
+  // TODO: find a better way to handle setting and restoring values
+  // at the very least, rename this to something better: ex,`getSetValues`
+  // `values` is confusing when reading this along side other code.
+  values: {
+    get (lastSet) {
+      const index = this.answerIndex
+      const previousValue = this.answer.values[index]
+
+      return previousValue
     },
 
-    answer: {
-      value: null
-    },
+    set (val) {
+      const index = this.answerIndex
+      const type = this.field.type
 
-    answerIndex: {
-      value: 1
-    },
-
-    fields: {
-      value: null
-    },
-
-    // TODO: find a better way to handle setting and restoring values
-    // at the very least, rename this to something better: ex,`getSetValues`
-    // `values` is confusing when reading this along side other code.
-    values: {
-      get (lastSet) {
-        const index = this.attr('answerIndex')
-        const previousValue = this.attr(`answer.values.${index}`)
-
-        return previousValue
-      },
-
-      set (val) {
-        const index = this.attr('answerIndex')
-        const type = this.attr('field.type')
-
-        // TODO: this conversion allows for future locales
-        // should probably be moved to a better place when that happens
-        if (type === 'number' || type === 'numberdollar') {
-          val = cString.textToNumber(val)
-        }
-
-        if (!this.attr('answer')) {
-          this.attr('answer', {})
-        }
-
-        if (!this.attr('answer.values')) {
-          this.attr('answer.values', [null])
-        }
-
-        this.attr(`answer.values.${index}`, val)
-
-        return val
+      // TODO: this conversion allows for future locales
+      // should probably be moved to a better place when that happens
+      if (type === 'number' || type === 'numberdollar') {
+        val = cString.textToNumber(val)
       }
-    },
 
-    errors: {
-      get () {
-        const testValue = this.attr('values')
-        return this.validateAnswer(testValue)
+      if (!this.answer) {
+        this.answer = new Answer()
       }
+      // TODO: this can probably be removed now we are assigning a new AnswerModel above
+      if (!this.answer.values) {
+        this.answer.values = [null]
+      }
+
+      this.answer.values[index] = val
+
+      return val
+    }
+  },
+
+  errors: {
+    get () {
+      const testValue = this.values
+      return this.validateAnswer(testValue)
     }
   },
 
   validateAnswer (val) {
-    const field = this.attr('field')
+    const field = this.field
 
     if (!field) return
 
@@ -113,9 +111,9 @@ export default CanMap.extend('AnswerVM', {
       case 'checkbox':
       case 'radio':
       case 'checkboxNOTA':
-        const fields = this.attr('fields')
-        const index = this.attr('answerIndex')
-        const varName = this.attr('field.name')
+        const fields = this.fields
+        const index = this.answerIndex
+        const varName = this.field.name
 
         const checkboxes = _filter(fields, function (f) {
           // if the field being validated is either 'checkbox' or 'checkboxNOTA',
@@ -130,7 +128,7 @@ export default CanMap.extend('AnswerVM', {
         })
 
         const anyChecked = _some(checkboxes, function (checkbox) {
-          return !!checkbox.attr(`_answerVm.answer.values.${index}`)
+          return !!checkbox._answerVm.answer.values[index]
         })
 
         validations.val = anyChecked || null

--- a/src/models/answervm.js
+++ b/src/models/answervm.js
@@ -12,7 +12,7 @@ export default DefineMap.extend('AnswerVM', {
   },
 
   answer: {
-    default: null
+    default: {}
   },
 
   answerIndex: {
@@ -139,5 +139,4 @@ export default DefineMap.extend('AnswerVM', {
 
     return invalid
   }
-
 })

--- a/src/models/answervm.js
+++ b/src/models/answervm.js
@@ -83,7 +83,7 @@ export default CanMap.extend('AnswerVM', {
       }
     })
 
-    validations.attr('val', val)
+    validations.val = val
 
     let invalid
 
@@ -133,7 +133,7 @@ export default CanMap.extend('AnswerVM', {
           return !!checkbox.attr(`_answerVm.answer.values.${index}`)
         })
 
-        validations.attr('val', anyChecked || null)
+        validations.val = anyChecked || null
 
         invalid = validations.required()
         break

--- a/src/models/answervm.js
+++ b/src/models/answervm.js
@@ -12,7 +12,7 @@ export default DefineMap.extend('AnswerVM', {
   },
 
   answer: {
-    default: {}
+    default: null
   },
 
   answerIndex: {
@@ -49,10 +49,10 @@ export default DefineMap.extend('AnswerVM', {
       }
       // TODO: this can probably be removed now we are assigning a new AnswerModel above
       if (!this.answer.values) {
-        this.answer.values = [null]
+        this.answer.set('values', [null])
       }
 
-      this.answer.values[index] = val
+      this.answer.values.set(index, val)
 
       return val
     }

--- a/src/models/app-state.js
+++ b/src/models/app-state.js
@@ -22,7 +22,7 @@ export const ViewerAppState = DefineMap.extend('ViewerAppState', {
     get () {
       const answers = this.interview && this.interview.attr('answers')
       const savedUserAvatar = answers.varGet('user avatar', 1)
-      return savedUserAvatar ? defaultUserAvatar.assign(JSON.parse(savedUserAvatar)) : defaultUserAvatar
+      return savedUserAvatar ? new UserAvatar((JSON.parse(savedUserAvatar))) : defaultUserAvatar
     }
   },
 

--- a/src/models/app-state.js
+++ b/src/models/app-state.js
@@ -5,6 +5,7 @@ import DefineMap from 'can-define/map/map'
 import DefineList from 'can-define/list/list'
 import queues from 'can-queues'
 import TraceMessage from '@caliorg/a2jdeps/models/trace-message'
+import ModalContent from '~/src/models/modal-content'
 
 const UserAvatar = DefineMap.extend('UserAvatar', {
   gender: { default: 'female' },
@@ -147,7 +148,9 @@ export const ViewerAppState = DefineMap.extend('ViewerAppState', {
   },
 
   modalContent: {
-    serialize: false
+    serialize: false,
+    Type: ModalContent,
+    Default: ModalContent
   },
 
   logic: {

--- a/src/models/app-state.js
+++ b/src/models/app-state.js
@@ -13,7 +13,7 @@ export const ViewerAppState = DefineMap.extend('ViewerAppState', {
     get () {
       const defaultUserAvatar = { gender: 'female', isOld: false, hasWheelchair: false, hairColor: 'brownDark', skinTone: 'medium' }
       const answers = this.interview && this.interview.attr('answers')
-      const savedUserAvatar = answers.attr('user avatar') && answers.attr('user avatar').values[1]
+      const savedUserAvatar = answers.varGet('user avatar', 1)
       const userAvatar = savedUserAvatar ? JSON.parse(savedUserAvatar) : defaultUserAvatar
       return new DefineMap(userAvatar)
     }

--- a/src/models/app-state.js
+++ b/src/models/app-state.js
@@ -6,16 +6,23 @@ import DefineList from 'can-define/list/list'
 import queues from 'can-queues'
 import TraceMessage from '@caliorg/a2jdeps/models/trace-message'
 
+const UserAvatar = DefineMap.extend('UserAvatar', {
+  gender: { default: 'female' },
+  isOld: { default: false },
+  hasWheelchair: { default: false },
+  hairColor: { default: 'brownDark' },
+  skinTone: { default: 'medium' }
+})
+const defaultUserAvatar = new UserAvatar()
+
 export const ViewerAppState = DefineMap.extend('ViewerAppState', {
   // skinTone, hairColor, gender, isOld, hasWheelChair
   userAvatar: {
     serialize: false,
     get () {
-      const defaultUserAvatar = { gender: 'female', isOld: false, hasWheelchair: false, hairColor: 'brownDark', skinTone: 'medium' }
       const answers = this.interview && this.interview.attr('answers')
       const savedUserAvatar = answers.varGet('user avatar', 1)
-      const userAvatar = savedUserAvatar ? JSON.parse(savedUserAvatar) : defaultUserAvatar
-      return new DefineMap(userAvatar)
+      return savedUserAvatar ? defaultUserAvatar.assign(JSON.parse(savedUserAvatar)) : defaultUserAvatar
     }
   },
 
@@ -208,6 +215,8 @@ export const ViewerAppState = DefineMap.extend('ViewerAppState', {
   connectedCallback () {
     const vm = this
 
+    // TODO: move this to helpers util and handle vm reference?
+    // depends on html, answers, and logic.eval
     const parseTextHelper = (html) => {
       // re-eval if answer values have updated via beforeCode'
       const answersChanged = vm.interview && vm.interview.attr('answers').serialize() // eslint-disable-line

--- a/src/models/app-state.js
+++ b/src/models/app-state.js
@@ -177,7 +177,7 @@ export const ViewerAppState = DefineMap.extend('ViewerAppState', {
 
     // batching here for performance reasons due to codeBefore string parsing
     queues.batch.start()
-    logic.exec(currentPage.attr('codeBefore'))
+    logic.exec(currentPage.codeBefore)
     queues.batch.stop()
 
     let postGotoPage = this.logic.attr('gotoPage')
@@ -222,7 +222,7 @@ export const ViewerAppState = DefineMap.extend('ViewerAppState', {
       if (!this.currentPage) { return }
 
       // handle codeBefore A2J logic
-      if (this.currentPage.attr('codeBefore')) {
+      if (this.currentPage.codeBefore) {
         this.traceMessage.addMessage({ key: 'codeBefore', fragments: [{ format: 'info', msg: 'Logic Before Question' }] })
         const newGotoPage = this.fireCodeBefore(this.currentPage, this.logic)
         if (newGotoPage) {

--- a/src/models/app-state.js
+++ b/src/models/app-state.js
@@ -198,7 +198,7 @@ export const ViewerAppState = DefineMap.extend('ViewerAppState', {
   },
 
   checkInfiniteLoop () {
-    if (this.infinite.attr('outOfRange')) {
+    if (this.infinite.outOfRange) {
       this.traceMessage.addMessage({
         key: 'infinite loop',
         fragments: [{

--- a/src/models/app-state.js
+++ b/src/models/app-state.js
@@ -29,7 +29,8 @@ export const ViewerAppState = DefineMap.extend('ViewerAppState', {
 
   traceMessage: {
     serialize: false,
-    default: () => new TraceMessage()
+    Type: TraceMessage,
+    Default: TraceMessage
   },
 
   showDebugPanel: {

--- a/src/models/field.js
+++ b/src/models/field.js
@@ -97,8 +97,8 @@ const Field = DefineMap.extend('Field', {
   }
 })
 
-Field.List = DefineList.extend({
-  Type: Field
-}, {})
+Field.List = DefineList.extend('FieldList', {
+  '#': Field
+})
 
 export default Field

--- a/src/models/field.js
+++ b/src/models/field.js
@@ -1,11 +1,9 @@
 import $ from 'jquery'
-import CanMap from 'can-map'
-import CanList from 'can-list'
+import DefineMap from 'can-define/map/map'
+import DefineList from 'can-define/list/list'
 import Answer from '~/src/models/answer'
 import normalizePath from '~/src/util/normalize-path'
 import setupPromise from 'can-reflect-promise'
-
-import 'can-map-define'
 
 /**
  * @module {can.Map} Field
@@ -13,25 +11,40 @@ import 'can-map-define'
  *
  * A map representing a field of an interview page
  */
-const Field = CanMap.extend('FieldModel', {
-  define: {
-    options: {
-      value: ''
-    },
+const Field = DefineMap.extend('Field', {
+  // these props set in src/models/page.fields is of Type: Field.List
+  calculator: {},
+  invalidPrompt: {},
+  label: {},
+  listData: {},
+  listSrc: {},
+  max: {},
+  maxChars: {},
+  min: {},
+  name: {},
+  order: {},
+  required: {},
+  sample: {},
+  type: {},
+  repeating: {},
+  values: {},
 
-    hasError: {},
+  options: {
+    default: ''
+  },
 
-    _answerVm: {},
+  hasError: {},
 
-    emptyAnswer: {
-      get () {
-        return new Answer({
-          name: this.attr('name').toLowerCase(),
-          repeating: this.attr('repeating'),
-          type: this.attr('type'),
-          values: [null]
-        })
-      }
+  _answerVm: {},
+
+  emptyAnswer: {
+    get () {
+      return new Answer({
+        name: this.name.toLowerCase(),
+        type: this.type,
+        repeating: this.repeating,
+        values: [null]
+      })
     }
   },
 
@@ -50,15 +63,15 @@ const Field = CanMap.extend('FieldModel', {
   getOptions (guidePath) {
     let dfd = $.Deferred()
     setupPromise(dfd)
-    let listSrc = this.attr('listSrc')
-    let listData = this.attr('listData')
+    let listSrc = this.listSrc
+    let listData = this.listData
 
     if (!listData && !listSrc) {
       return dfd.reject(new Error('Missing listData or listSrc values'))
     }
 
     if (listData) {
-      this.attr('options', listData)
+      this.options = listData
       return dfd.resolve(listData)
     }
 
@@ -72,7 +85,7 @@ const Field = CanMap.extend('FieldModel', {
         .then(options => {
           // strip anything before or after option tags
           let formatted = options.replace(/<select>/ig, '').replace(/<\/select/ig, '')
-          this.attr('options', formatted)
+          this.options = formatted
           dfd.resolve(formatted)
         })
         .then(null, function (error) {
@@ -84,8 +97,8 @@ const Field = CanMap.extend('FieldModel', {
   }
 })
 
-Field.List = CanList.extend({
-  Map: Field
+Field.List = DefineList.extend({
+  Type: Field
 }, {})
 
 export default Field

--- a/src/models/field.js
+++ b/src/models/field.js
@@ -12,7 +12,7 @@ import setupPromise from 'can-reflect-promise'
  * A map representing a field of an interview page
  */
 const Field = DefineMap.extend('Field', {
-  // these props set in src/models/page.fields is of Type: Field.List
+  // these props set in src/models/page.fields which is of Type: Field.List
   calculator: {},
   invalidPrompt: {},
   label: {},
@@ -30,7 +30,7 @@ const Field = DefineMap.extend('Field', {
   values: {},
 
   options: {
-    default: ''
+    default: () => ''
   },
 
   hasError: {},

--- a/src/models/interview.js
+++ b/src/models/interview.js
@@ -176,8 +176,8 @@ const Interview = Model.extend('InterviewModel', {
       get () {
         let result
         const answers = this.attr('answers')
-        const userAvatar = answers.varGet('user avatar')
-        const gender = answers.varGet('user gender')
+        const userAvatar = answers['user avatar']
+        const gender = answers['user gender']
 
         if (userAvatar || gender) {
           const genderValues = (gender && gender.values) || []
@@ -269,8 +269,8 @@ const Interview = Model.extend('InterviewModel', {
     queues.batch.start()
 
     this.attr('answers').forEach((answer) => {
-      if (answer && answer.attr && answer.attr('values')) {
-        answer.attr('values', [null])
+      if (answer) {
+        answer.clearAnswer()
       }
     })
 

--- a/src/models/interview.js
+++ b/src/models/interview.js
@@ -128,10 +128,10 @@ const Interview = Model.extend('InterviewModel', {
         const pages = this.attr('pages')
 
         // This is an array of step numbers which have pages associated to them
-        const stepsNumbers = pages.map(p => p.attr('step.number')).attr()
+        const stepsNumbers = pages.map(p => p.step.number)
 
         // Filters all the steps that own pages.
-        return steps.filter(s => _includes(stepsNumbers, s.attr('number')))
+        return steps.filter(s => _includes(stepsNumbers, s.number))
       }
     },
 
@@ -293,7 +293,7 @@ const Interview = Model.extend('InterviewModel', {
     let pages = this.attr('pages')
 
     return _find(pages, function (page) {
-      return page.attr('name') === name
+      return page.name === name
     })
   }
 })

--- a/src/models/interview.js
+++ b/src/models/interview.js
@@ -175,20 +175,27 @@ const Interview = Model.extend('InterviewModel', {
       serialize: false,
       get () {
         let result
+        // unsealed DefineMap -> answers.varCreate('newVar', 'Text', false)
         const answers = this.attr('answers')
-        const userAvatar = answers['user avatar']
-        const gender = answers['user gender']
+        // It's possible either or both of these keys could be created after the first run of this getter
+        const userAvatarAnswer = answers.get('user avatar')
+        const userGenderAnswer = answers.get('user gender')
 
-        if (userAvatar || gender) {
-          const genderValues = (gender && gender.values) || []
-          const userAvatarValues = (userAvatar && userAvatar.values) || []
-          const userAvatarValue = userAvatarValues[1] && JSON.parse(userAvatarValues[1]).gender
-          let lastValue = userAvatarValue || genderValues.pop()
+        const userAvatarValuesList = userAvatarAnswer && userAvatarAnswer.get('values')
+        const userGenderValuesList = userGenderAnswer && userGenderAnswer.get('values')
 
-          if (_isString(lastValue) && lastValue.length) {
-            lastValue = lastValue.toLowerCase()
+        // built-in answerVars `user gender` and `user avatar` only support one answer currently
+        const userAvatarJson = userAvatarValuesList && userAvatarValuesList.get(1)
+        const userGenderValue = userGenderValuesList && userGenderValuesList.get(1)
 
-            switch (lastValue) {
+        if (userAvatarJson || userGenderValue) {
+          const userAvatarGenderValue = userAvatarJson && JSON.parse(userAvatarJson).gender
+          let lastGenderValue = userAvatarGenderValue || userGenderValue
+
+          if (lastGenderValue) {
+            lastGenderValue = lastGenderValue.toLowerCase()
+
+            switch (lastGenderValue) {
               case 'm':
               case 'male':
                 result = 'male'

--- a/src/models/interview.js
+++ b/src/models/interview.js
@@ -176,8 +176,8 @@ const Interview = Model.extend('InterviewModel', {
       get () {
         let result
         const answers = this.attr('answers')
-        const userAvatar = answers.attr('user avatar')
-        const gender = answers.attr('user gender')
+        const userAvatar = answers.varGet('user avatar')
+        const gender = answers.varGet('user gender')
 
         if (userAvatar || gender) {
           const genderValues = (gender && gender.attr('values').attr()) || []
@@ -226,7 +226,7 @@ const Interview = Model.extend('InterviewModel', {
 
         _keys(vars).forEach(function (key) {
           let variable = vars[key]
-          let answer = answers.attr(key.toLowerCase())
+          let answer = answers.varGet(key.toLowerCase())
 
           let values = answer ? answer.attr('values').attr() : variable.values
 

--- a/src/models/interview.js
+++ b/src/models/interview.js
@@ -111,6 +111,9 @@ const Interview = Model.extend('InterviewModel', {
   }
 }, {
   define: {
+    // 2-letter string code, 'en'
+    language: {},
+
     answers: {
       Type: Answers,
 

--- a/src/models/interview.js
+++ b/src/models/interview.js
@@ -180,8 +180,8 @@ const Interview = Model.extend('InterviewModel', {
         const gender = answers.varGet('user gender')
 
         if (userAvatar || gender) {
-          const genderValues = (gender && gender.attr('values').attr()) || []
-          const userAvatarValues = (userAvatar && userAvatar.attr('values').attr()) || []
+          const genderValues = (gender && gender.values) || []
+          const userAvatarValues = (userAvatar && userAvatar.values) || []
           const userAvatarValue = userAvatarValues[1] && JSON.parse(userAvatarValues[1]).gender
           let lastValue = userAvatarValue || genderValues.pop()
 
@@ -228,7 +228,7 @@ const Interview = Model.extend('InterviewModel', {
           let variable = vars[key]
           let answer = answers.varGet(key.toLowerCase())
 
-          let values = answer ? answer.attr('values').attr() : variable.values
+          let values = answer ? answer.values : variable.values
 
           if (!variable.repeating) {
             // handle [ null ] or [ null, "foo" ] scenarios

--- a/src/models/modal-content.js
+++ b/src/models/modal-content.js
@@ -7,9 +7,6 @@ export default DefineMap.extend('ModalContent', {
   // shows glyphicon-lifebuoy if emptry
   title: { default: '' },
 
-  // used for 'zoom in' on long text fields
-  textLongValue: { default: '' },
-
   // question text
   text: { default: '' },
 
@@ -28,7 +25,8 @@ export default DefineMap.extend('ModalContent', {
   // text transcript of video content
   helpReader: { default: '' },
 
-  // only used for textlong modals
+  // only used for textlong `zoom` modals
+  textlongValue: { default: '' },
   textlongVM: { Default: DefineMap },
   field: { Default: DefineMap }
 })

--- a/src/models/page.js
+++ b/src/models/page.js
@@ -29,9 +29,8 @@ const Page = DefineMap.extend('Page Model', {
   }
 })
 
-Page.List = DefineList.extend('Page List', {
-  '#': Page
-}, {
+Page.List = DefineList.extend('PageList', {
+  '#': Page,
   find (name) {
     return _find(this, p => p.name === name)
   }

--- a/src/models/page.js
+++ b/src/models/page.js
@@ -25,7 +25,7 @@ const Page = CanMap.extend({
         let fields = this.attr('fields')
 
         return !!_find(fields, function (field) {
-          let fieldName = field.attr('name').toLowerCase()
+          let fieldName = field.name.toLowerCase()
           return fieldName === 'user gender' || fieldName === 'user avatar'
         })
       }

--- a/src/models/page.js
+++ b/src/models/page.js
@@ -1,43 +1,39 @@
-import CanMap from 'can-map'
-import CanList from 'can-list'
+import DefineMap from 'can-define/map/map'
+import DefineList from 'can-define/list/list'
 import _find from 'lodash/find'
 import Field from '~/src/models/field'
 
-import 'can-map-define'
+const Page = DefineMap.extend('Page Model', {
+  step: {
+    // forces the conversion of TStep objects when converting
+    // `window.gGuide` to an Interview model instance.
+    Type: DefineMap
+  },
 
-const Page = CanMap.extend({
-  define: {
-    step: {
-      // forces the conversion of TStep objects when converting
-      // `window.gGuide` to an Interview model instance.
-      Type: CanMap
-    },
+  fields: {
+    Type: Field.List
+  },
 
-    fields: {
-      Type: Field.List
-    },
+  // whether this page has an 'user gender' or 'user avatar' field.
+  hasUserGenderOrAvatarField: {
+    serialize: false,
 
-    // whether this page has an 'user gender' or 'user avatar' field.
-    hasUserGenderOrAvatarField: {
-      serialize: false,
+    get () {
+      let fields = this.fields
 
-      get () {
-        let fields = this.attr('fields')
-
-        return !!_find(fields, function (field) {
-          let fieldName = field.name.toLowerCase()
-          return fieldName === 'user gender' || fieldName === 'user avatar'
-        })
-      }
+      return !!_find(fields, function (field) {
+        let fieldName = field.name.toLowerCase()
+        return fieldName === 'user gender' || fieldName === 'user avatar'
+      })
     }
   }
 })
 
-Page.List = CanList.extend({
-  Map: Page
+Page.List = DefineList.extend('Page List', {
+  '#': Page
 }, {
   find (name) {
-    return _find(this, p => p.attr('name') === name)
+    return _find(this, p => p.name === name)
   }
 })
 

--- a/src/models/page.js
+++ b/src/models/page.js
@@ -11,7 +11,8 @@ const Page = DefineMap.extend('Page Model', {
   },
 
   fields: {
-    Type: Field.List
+    Type: Field.List,
+    default: () => []
   },
 
   // whether this page has an 'user gender' or 'user avatar' field.

--- a/src/models/tests/answer-test.html
+++ b/src/models/tests/answer-test.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Answer Model Tests</title>
+  </head>
+
+  <body>
+    <div id="mocha"></div>
+    <div id="test-area"></div>
+
+    <script src="../../../node_modules/steal/steal.js"
+      data-mocha="bdd"
+      data-main="~/src/models/tests/answer-test"></script>
+  </body>
+</html>

--- a/src/models/tests/answer-test.js
+++ b/src/models/tests/answer-test.js
@@ -15,7 +15,7 @@ describe('Answer Model', function () {
     expectedResult = {
       name: '',
       repeating: false,
-      type: '',
+      type: 'Text',
       values: [null]
     }
 

--- a/src/models/tests/answer-test.js
+++ b/src/models/tests/answer-test.js
@@ -1,0 +1,38 @@
+import { assert } from 'chai'
+import Answer from '~/src/models/answer'
+
+import 'steal-mocha'
+
+describe('Answer Model', function () {
+  let answer
+  let expectedResult
+  beforeEach(() => {
+    answer = new Answer()
+  })
+
+  it('AnswerModel new instance', () => {
+    answer = new Answer()
+    expectedResult = {
+      name: '',
+      repeating: false,
+      type: '',
+      values: [null]
+    }
+
+    assert.deepEqual(answer.serialize(), expectedResult, 'new Answer() has sane defaults')
+
+    // repeating should stay the default
+    answer = new Answer({name: 'foo', type: 'text', values: [null, 'JessBob']})
+    expectedResult = {
+      name: 'foo',
+      repeating: false,
+      type: 'text',
+      values: [null, 'JessBob']
+    }
+    assert.deepEqual(answer.serialize(), expectedResult, 'new Answer() takes values to the constructor')
+  })
+
+  afterEach(() => {
+    answer = null
+  })
+})

--- a/src/models/tests/answer-test.js
+++ b/src/models/tests/answer-test.js
@@ -42,7 +42,7 @@ describe('Answer Model', function () {
     }
 
     answer.clearAnswer()
-    assert.deepEqual(answer.values, [null], 'should reset values to default of [null]')
+    assert.deepEqual(answer.values.serialize(), [null], 'should reset values to default of [null]')
   })
 
   afterEach(() => {

--- a/src/models/tests/answer-test.js
+++ b/src/models/tests/answer-test.js
@@ -32,6 +32,19 @@ describe('Answer Model', function () {
     assert.deepEqual(answer.serialize(), expectedResult, 'new Answer() takes values to the constructor')
   })
 
+  it('clearAnswer()', () => {
+    answer = new Answer({values: [null, 'foo', 'bar', 'baz']})
+    expectedResult = {
+      name: '',
+      repeating: false,
+      type: '',
+      values: [null]
+    }
+
+    answer.clearAnswer()
+    assert.deepEqual(answer.values, [null], 'should reset values to default of [null]')
+  })
+
   afterEach(() => {
     answer = null
   })

--- a/src/models/tests/answers-test.html
+++ b/src/models/tests/answers-test.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Answers Model Tests</title>
+  </head>
+
+  <body>
+    <div id="mocha"></div>
+    <div id="test-area"></div>
+
+    <script src="../../../node_modules/steal/steal.js"
+      data-mocha="bdd"
+      data-main="~/src/models/tests/answers-test"></script>
+  </body>
+</html>

--- a/src/models/tests/answers-test.js
+++ b/src/models/tests/answers-test.js
@@ -1,29 +1,45 @@
 import { assert } from 'chai'
 import Answers from '~/src/models/answers'
+import Lang from '~/src/mobile/util/lang'
+import DefineMap from 'can-define/map/map'
+import Answer from '~/src/models/answer'
 
 import 'steal-mocha'
 
 describe('Answers Model', function () {
   let answers
+  let lang = new Lang()
   beforeEach(() => {
-    answers = new Answers()
+    answers = new Answers({ lang })
   })
 
   afterEach(() => {
     answers = null
   })
 
+  it('added props and lang prop types preserved', () => {
+    answers.varCreate('Foo', 'Text', false)
+
+    const fooInstanceOfAnswer = (answers.foo instanceof Answer)
+    const langInstanceOfDefineMap = (answers.lang instanceof DefineMap)
+    const langInstanceOfAnswer = (answers.lang instanceof Answer)
+
+    assert.isTrue(fooInstanceOfAnswer, 'added props should be Answer Models')
+    assert.isTrue(langInstanceOfDefineMap, 'passed in lang prop should be DefineMap')
+    assert.isFalse(langInstanceOfAnswer, 'passed in lang prop should NOT be an Answer Model')
+  })
+
   it('serialize', () => {
     answers.varCreate('Foo', 'Text', false)
-    let expectedResult = { _answerMap: {'foo': { name: 'Foo', type: 'Text', repeating: false, values: [null] }} }
+    let expectedResult = {'foo': { name: 'Foo', type: 'Text', repeating: false, values: [null] }}
     assert.deepEqual(answers.serialize(), expectedResult, 'should serialize() answers with props ignoring `lang` prop')
 
     answers.varCreate('Bar', 'Text', false)
     answers.varSet('bar', 'baz')
-    expectedResult = { _answerMap: {
+    expectedResult = {
       'foo': { name: 'Foo', type: 'Text', repeating: false, values: [null] },
       'bar': { name: 'Bar', type: 'Text', repeating: false, values: [null, 'baz'] }
-    } }
+    }
     assert.deepEqual(answers.serialize(), expectedResult, 'should serialize() answers with props and updated values ignoring `lang` prop')
   })
 

--- a/src/models/tests/answers-test.js
+++ b/src/models/tests/answers-test.js
@@ -13,6 +13,18 @@ describe('Answers Model', function () {
     answers = null
   })
 
+  it('varExists and varCreate', function () {
+    let varExists = answers.varExists('foo')
+    assert.equal(varExists, null, 'should return null if var does not exist')
+
+    let answerModel = answers.varCreate('foo', 'text', false)
+    varExists = answers.varExists('foo')
+    assert.deepEqual(varExists.serialize(), answerModel.serialize(), 'should return the answerModel if it exists')
+
+    answerModel = answers.varCreate('bar', 'text', false)
+    varExists = answers.varExists('bar')
+    assert.deepEqual(varExists.serialize(), answerModel.serialize(), 'handles repeated varCreate calls')
+  })
   it('does not set TF vars to non boolean values', function () {
     answers.varCreate('gotMilk', 'TF', 'false')
 
@@ -35,7 +47,7 @@ describe('Answers Model', function () {
     answers.varCreate('gotMilk', 'TF', 'false')
     assert.equal(answers.varGet('gotMilk', 1), undefined, 'new TF vars should be set to undefined')
 
-    answers.gotmilk.attr('values').push('true')
+    answers.gotmilk.values.push('true')
     assert.equal(answers.varGet('gotMilk', 1), true, 'should cast legacy string values to boolean')
   })
 

--- a/src/models/tests/answers-test.js
+++ b/src/models/tests/answers-test.js
@@ -13,6 +13,20 @@ describe('Answers Model', function () {
     answers = null
   })
 
+  it('serialize', () => {
+    answers.varCreate('Foo', 'Text', false)
+    let expectedResult = { _answerMap: {'foo': { name: 'Foo', type: 'Text', repeating: false, values: [null] }} }
+    assert.deepEqual(answers.serialize(), expectedResult, 'should serialize() answers with props ignoring `lang` prop')
+
+    answers.varCreate('Bar', 'Text', false)
+    answers.varSet('bar', 'baz')
+    expectedResult = { _answerMap: {
+      'foo': { name: 'Foo', type: 'Text', repeating: false, values: [null] },
+      'bar': { name: 'Bar', type: 'Text', repeating: false, values: [null, 'baz'] }
+    } }
+    assert.deepEqual(answers.serialize(), expectedResult, 'should serialize() answers with props and updated values ignoring `lang` prop')
+  })
+
   it('varExists and varCreate', function () {
     let varExists = answers.varExists('foo')
     assert.equal(varExists, null, 'should return null if var does not exist')
@@ -35,7 +49,7 @@ describe('Answers Model', function () {
   })
 
   it('should set proper boolean values for TF vars', function () {
-    answers.varCreate('gotMilk', 'TF', 'false')
+    answers.varCreate('gotMilk', 'TF', false)
 
     answers.varSet('gotMilk', true, 1)
     assert.equal(answers.varGet('gotMilk', 1), true, 'did not set to boolean true')
@@ -44,11 +58,11 @@ describe('Answers Model', function () {
   })
 
   it('should get boolean values for TF vars', function () {
-    answers.varCreate('gotMilk', 'TF', 'false')
+    answers.varCreate('gotMilk', 'TF', false)
     assert.equal(answers.varGet('gotMilk', 1), undefined, 'new TF vars should be set to undefined')
 
-    answers.gotmilk.values.push('true')
-    assert.equal(answers.varGet('gotMilk', 1), true, 'should cast legacy string values to boolean')
+    answers.varSet('gotmilk', 'true')
+    assert.equal(answers.varGet('gotMilk', 1), undefined, 'should return undefined for non boolean values')
   })
 
   it('handles zero and falsy values for number types', function () {

--- a/src/models/tests/answervm-test.html
+++ b/src/models/tests/answervm-test.html
@@ -8,7 +8,7 @@
     <div id="mocha"></div>
     <div id="test-area"></div>
 
-    <script src="../../node_modules/steal/steal.js"
+    <script src="../../../node_modules/steal/steal.js"
       data-mocha="bdd"
       data-main="~/src/models/tests/answervm-test"></script>
   </body>

--- a/src/models/tests/answervm-test.js
+++ b/src/models/tests/answervm-test.js
@@ -1,5 +1,6 @@
 import { assert } from 'chai'
 import Field from '~/src/models/field'
+import Answer from '~/src/models/answer'
 import Answers from '~/src/models/answers'
 import AnswerVM from '~/src/models/answervm'
 
@@ -13,9 +14,8 @@ describe('AnswerViewModel', function () {
   })
 
   it('serialize', function () {
-    const answers = new Answers()
-    const answer = answers.varCreate('user gender', 'text', false)
-    avm.answer = answer
+    const answerModel = new Answer({ name: 'user gender', type: 'text', repeating: false, values: [null] })
+    const answers = new Answers({ answer: answerModel })
 
     avm.values = 'm'
     assert.deepEqual(answers.serialize(), {

--- a/src/models/tests/answervm-test.js
+++ b/src/models/tests/answervm-test.js
@@ -14,15 +14,24 @@ describe('AnswerViewModel', function () {
   })
 
   it('serialize', function () {
-    const answerModel = new Answer({ name: 'user gender', type: 'text', repeating: false, values: [null] })
-    const answers = new Answers({ answer: answerModel })
+    const answers = new Answers()
+
+    const answer = new Answer({
+      type: 'text',
+      values: [null],
+      repeating: false,
+      name: 'user gender'
+    })
+
+    answers.assign({ 'user gender': answer })
+    avm.answer = answer
 
     avm.values = 'm'
     assert.deepEqual(answers.serialize(), {
       'user gender': {
-        type: 'text',
-        repeating: false,
         name: 'user gender',
+        repeating: false,
+        type: 'text',
         values: [null, 'm']
       }
     }, 'single value serialize')
@@ -46,7 +55,7 @@ describe('AnswerViewModel', function () {
       avm.values = false
     })
 
-    assert.deepEqual(avm.answer.values, [null, false])
+    assert.deepEqual(avm.answer.values.serialize(), [null, false])
   })
 
   it('sets number field answer correctly from text input', function () {
@@ -55,7 +64,7 @@ describe('AnswerViewModel', function () {
     avm.assign({ field, answer: field.emptyAnswer })
     avm.values = '123,456.78'
 
-    assert.deepEqual(avm.answer.values, [null, 123456.78])
+    assert.deepEqual(avm.answer.values.serialize(), [null, 123456.78])
   })
 
   it('sets zero number values correctly', function () {
@@ -64,7 +73,7 @@ describe('AnswerViewModel', function () {
     avm.assign({ field, answer: field.emptyAnswer })
     avm.values = '0'
 
-    assert.deepEqual(avm.answer.values, [null, 0])
+    assert.deepEqual(avm.answer.values.serialize(), [null, 0])
   })
 
   describe('validating checkboxes', function () {

--- a/src/models/tests/app-state-test.html
+++ b/src/models/tests/app-state-test.html
@@ -8,7 +8,7 @@
     <div id="mocha"></div>
     <div id="test-area"></div>
 
-    <script src="../../node_modules/steal/steal.js"
+    <script src="../../../node_modules/steal/steal.js"
       data-mocha="bdd"
       data-main="~/src/models/tests/app-state-test"></script>
   </body>

--- a/src/models/tests/app-state-test.js
+++ b/src/models/tests/app-state-test.js
@@ -2,8 +2,8 @@ import { assert } from 'chai'
 import AppState from '~/src/models/app-state'
 import Interview from '~/src/models/interview'
 import Logic from '~/src/mobile/util/logic'
-import DefineMap from 'can-define/map/map'
-import CanMap from 'can-map'
+import TraceMessage from '@caliorg/a2jdeps/models/trace-message'
+import Answers from '~/src/models/answers'
 import stache from 'can-stache'
 import sinon from 'sinon'
 import '~/src/models/tests/fixtures/'
@@ -25,8 +25,8 @@ describe('AppState', function () {
 
     promise.then(function (_interview) {
       interview = _interview
-      answers = new CanMap()
-      traceMessage = new DefineMap({ addMessage: sinon.stub() })
+      answers = new Answers()
+      traceMessage = new TraceMessage({ addMessage: sinon.stub() })
       interview.attr('answers', answers)
 
       logic = new Logic({ interview })

--- a/src/models/tests/app-state-test.js
+++ b/src/models/tests/app-state-test.js
@@ -63,7 +63,7 @@ describe('AppState', function () {
   it('restores userAvatar from saved interview.answers ', function () {
     const savedAvatar = JSON.stringify({ gender: 'male', isOld: false, hasWheelchair: true, hairColor: 'red', skinTone: 'medium' })
     const answers = appState.interview.attr('answers')
-    answers.attr('user avatar', { name: 'user avatar', values: [null, savedAvatar] })
+    answers.varSet('user avatar', savedAvatar)
     assert.deepEqual(appState.userAvatar.serialize(), { gender: 'male', isOld: false, hasWheelchair: true, hairColor: 'red', skinTone: 'medium' }, 'should set defaultAvatar')
   })
 

--- a/src/models/tests/app-state-test.js
+++ b/src/models/tests/app-state-test.js
@@ -50,6 +50,7 @@ describe('AppState', function () {
   it('parseText helper', function () {
     const parseText = stache.getHelper('parseText')
     const answers = appState.interview.attr('answers')
+    answers.varCreate('client first name te', 'Text', false)
     answers.varSet('client first name te', 'JessBob', 1)
     const result = parseText('My name is %%[Client first name TE]%%')
     assert.equal(result, 'My name is JessBob', 'should resolve macros in text')

--- a/src/models/tests/app-state-test.js
+++ b/src/models/tests/app-state-test.js
@@ -37,7 +37,7 @@ describe('AppState', function () {
 
       // collect the actual page names of the interview
       pages = interview.attr('pages')
-      pageNames = pages.map(page => page.attr('name'))
+      pageNames = pages.map(page => page.name)
 
       done()
     })
@@ -92,8 +92,9 @@ describe('AppState', function () {
 
   it('handles repeatVarValues', function () {
     const answers = appState.interview.attr('answers')
+    const page = appState.interview.attr('pages')[1]
     answers.varSet('childcount', 1)
-    interview.attr('pages.1.repeatVar', 'childCount')
+    page.repeatVar = 'childCount'
     appState.page = pageNames[1]
 
     assert.equal(appState.visitedPages.length, 1, 'appState.visitedPages should be correct length')
@@ -102,10 +103,10 @@ describe('AppState', function () {
   })
 
   it('handles following pages without repeatVarValues', function () {
-    interview.attr('pages.1.repeatVar', 'childCount')
     const answers = appState.interview.attr('answers')
+    const page = appState.interview.attr('pages')[1]
     answers.varSet('childcount', 1)
-    interview.attr('pages.1.repeatVar', 'childCount')
+    page.repeatVar = 'childCount'
     appState.page = pageNames[1]
 
     assert.equal(appState.visitedPages.length, 1, 'appState.visitedPages should be correct length')
@@ -113,16 +114,16 @@ describe('AppState', function () {
     assert.equal(appState.visitedPages[0].repeatVarValue, '1', 'page has repeatVarValue')
 
     appState.page = pageNames[2]
-    // answers.varSet('childcount', null)
     assert.equal(appState.visitedPages.length, 2, 'appState.visitedPages should be correct length')
     assert.equal(appState.visitedPages[0].repeatVar, '', 'page should not have repeatVar')
-    assert.equal(appState.visitedPages[0].repeatVarValue, null, 'page has no repeatVarValue')
+    assert.isTrue(typeof appState.visitedPages[0].repeatVarValue === 'undefined', 'page has no repeatVarValue')
   })
 
   it('handles repeatVarValue changes with same page name', function () {
-    interview.attr('pages.1.repeatVar', 'childCount')
     const answers = appState.interview.attr('answers')
+    const page = appState.interview.attr('pages')[1]
     answers.varSet('childcount', 1)
+    page.repeatVar = 'childCount'
     appState.page = pageNames[1]
 
     assert.equal(appState.visitedPages.length, 1, 'first page appState.visitedPages')
@@ -140,7 +141,7 @@ describe('AppState', function () {
     // simulate logic changing gotoPage based on A2J codeBefore script
     logic.attr('gotoPage', pageNames[1])
     logic.exec = function () { logic.attr('gotoPage', pageNames[2]) }
-    interview.attr('pages.0.codeBefore', 'a2j script is here, fired by logic.exec above to change gotoPage')
+    interview.attr('pages')[0].codeBefore = 'a2j script is here, fired by logic.exec above to change gotoPage'
 
     appState.page = pageNames[0]
 
@@ -180,15 +181,15 @@ describe('AppState', function () {
 
   it('changing selectedPageIndex resolves page', () => {
     // populate visitedPages
-    appState.page = pages.attr(2).name
-    appState.page = pages.attr(1).name
-    appState.page = pages.attr(0).name
+    appState.page = pages[2].name
+    appState.page = pages[1].name
+    appState.page = pages[0].name
 
     appState.selectedPageIndex = '1'
 
     assert.equal(
       appState.page,
-      pages.attr(appState.selectedPageIndex).attr('name'),
+      pages[appState.selectedPageIndex].name,
       'should set appState.page to page 1'
     )
 
@@ -196,23 +197,23 @@ describe('AppState', function () {
 
     assert.equal(
       appState.page,
-      pages.attr(appState.selectedPageIndex).attr('name'),
+      pages[appState.selectedPageIndex].name,
       'should set appState.page to page 1'
     )
   })
 
   it('selectedPageName', function () {
     // navigate to first page
-    appState.page = pages.attr(0).name
+    appState.page = pages[0].name
     // navigate to second page
-    appState.page = pages.attr(1).name
+    appState.page = pages[1].name
 
     appState.selectedPageIndex = 1
-    assert.equal(appState.selectedPageName, pages.attr(0).attr('name'),
+    assert.equal(appState.selectedPageName, pages[0].name,
       'should return most recently visited page name')
 
     appState.selectedPageIndex = 0
-    assert.equal(appState.selectedPageName, pages.attr(1).attr('name'),
+    assert.equal(appState.selectedPageName, pages[1].name,
       'should return second page name')
   })
 

--- a/src/models/tests/field-test.html
+++ b/src/models/tests/field-test.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Field Model Tests</title>
+  </head>
+
+  <body>
+    <div id="mocha"></div>
+    <div id="test-area"></div>
+
+    <script src="../../../node_modules/steal/steal.js"
+      data-mocha="bdd"
+      data-main="~/src/models/tests/field-test"></script>
+  </body>
+</html>

--- a/src/models/tests/field-test.js
+++ b/src/models/tests/field-test.js
@@ -1,0 +1,46 @@
+import { assert } from 'chai'
+import Field from '~/src/models/field'
+import Answer from '~/src/models/answer'
+
+import 'steal-mocha'
+
+describe('Field Model', function () {
+  let fieldModel
+  let expectedResult
+  beforeEach(() => {
+    fieldModel = new Field()
+  })
+
+  it('options', () => {
+    assert.equal(fieldModel.options, '', 'new Field() options default to empty string')
+  })
+
+  it('emptyAnswer', () => {
+    expectedResult = {
+      name: 'firstname',
+      type: 'text',
+      repeating: false,
+      values: [null]
+    }
+
+    fieldModel.assign(expectedResult)
+
+    const emptyAnswer = fieldModel.emptyAnswer
+    assert.deepEqual(emptyAnswer.serialize(), expectedResult, 'empty answer should match set Field props')
+
+    const instanceOfAnswer = emptyAnswer instanceof Answer
+    assert.equal(instanceOfAnswer, true, 'empty answer should be instance of Answer model')
+  })
+
+  it('getOptions', () => {
+    const colorList = '<option>Pink</option><option>Blue</option><option>Red</option>'
+    fieldModel.listData = colorList
+    fieldModel.getOptions('')
+
+    assert.equal(fieldModel.options, '<option>Pink</option><option>Blue</option><option>Red</option>', 'getOptions should set Field.options')
+  })
+
+  afterEach(() => {
+    fieldModel = null
+  })
+})

--- a/src/models/tests/fixtures/parse-model-interview.json
+++ b/src/models/tests/fixtures/parse-model-interview.json
@@ -5,7 +5,8 @@
       "name": "1-Introduction",
       "fields": [{
         "name": "user gender",
-        "type": "text"
+        "type": "text",
+        "options": ""
       }]
     }
   },

--- a/src/models/tests/interview-test.html
+++ b/src/models/tests/interview-test.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Interview Model Tests</title>
+  </head>
+
+  <body>
+    <div id="mocha"></div>
+    <div id="test-area"></div>
+
+    <script src="../../../node_modules/steal/steal.js"
+      data-mocha="bdd"
+      data-main="~/src/models/tests/interview-test"></script>
+  </body>
+</html>

--- a/src/models/tests/interview-test.js
+++ b/src/models/tests/interview-test.js
@@ -1,6 +1,10 @@
 import { assert } from 'chai'
 import Interview from '~/src/models/interview'
-import CanMap from 'can-map'
+import Answers from '~/src/models/answers'
+
+import '~/src/models/tests/fixtures/'
+
+import 'steal-mocha'
 
 describe('Interview model', function () {
   it('parseModels', function () {
@@ -81,10 +85,7 @@ describe('Interview model', function () {
       assert.notProperty(answers.serialize(), 'user gender', 'interview has no "user gender" variable')
       assert.isUndefined(interview.attr('avatarGender'))
 
-      answers.varSet('user gender', {
-        name: 'user gender',
-        values: [null]
-      })
+      answers.varCreate('user gender', 'Text', false)
       assert.property(answers.serialize(), 'user gender')
       assert.isUndefined(interview.attr('avatarGender'), 'variable has no value')
 
@@ -166,7 +167,7 @@ describe('Interview model', function () {
 
     beforeEach(function () {
       interview = new Interview()
-      let answers = new CanMap({
+      let answers = new Answers({
         name: {
           comment: '',
           name: 'Name',
@@ -202,8 +203,8 @@ describe('Interview model', function () {
       let answers = interview.attr('answers')
       interview.clearAnswers()
 
-      let salary = answers.varGet('salary')
-      let values = salary.attr('values')
+      let salary = answers['salary']
+      let values = salary.values
       assert.equal(values.length, 1)
       assert.equal(values[0], null)
     })
@@ -213,7 +214,7 @@ describe('Interview model', function () {
       interview.clearAnswers()
 
       answers.forEach(function (answer) {
-        let values = answer.attr('values')
+        let values = answer.values
         if (values) { // skip answers without values prop
           assert.equal(values.length, 1)
           assert.equal(values[0], null)
@@ -225,7 +226,7 @@ describe('Interview model', function () {
       let answers = interview.attr('answers')
       interview.clearAnswers()
 
-      let lang = answers.varGet('lang')
+      let lang = answers['lang']
       assert.notProperty(lang, 'values', 'no values array added to lang')
     })
   })

--- a/src/models/tests/interview-test.js
+++ b/src/models/tests/interview-test.js
@@ -78,21 +78,20 @@ describe('Interview model', function () {
     it('computes its value from the answer of the "user gender" variable', function () {
       let answers = interview.attr('answers')
 
-      assert.notProperty(answers.attr(), 'user gender',
-        'interview has no "user gender" variable')
+      assert.notProperty(answers.serialize(), 'user gender', 'interview has no "user gender" variable')
       assert.isUndefined(interview.attr('avatarGender'))
 
-      answers.attr('user gender', {
+      answers.varSet('user gender', {
         name: 'user gender',
         values: [null]
       })
-      assert.property(answers.attr(), 'user gender')
+      assert.property(answers.serialize(), 'user gender')
       assert.isUndefined(interview.attr('avatarGender'), 'variable has no value')
 
-      answers.attr('user gender').attr('values').push('m')
+      answers.varSet('user gender', 'm')
       assert.equal(interview.attr('avatarGender'), 'male')
 
-      answers.attr('user gender').attr('values').push('female')
+      answers.varSet('user gender', 'female')
       assert.equal(interview.attr('avatarGender'), 'female')
     })
   })
@@ -203,7 +202,7 @@ describe('Interview model', function () {
       let answers = interview.attr('answers')
       interview.clearAnswers()
 
-      let salary = answers.attr('salary')
+      let salary = answers.varGet('salary')
       let values = salary.attr('values')
       assert.equal(values.length, 1)
       assert.equal(values[0], null)
@@ -226,7 +225,7 @@ describe('Interview model', function () {
       let answers = interview.attr('answers')
       interview.clearAnswers()
 
-      let lang = answers.attr('lang')
+      let lang = answers.varGet('lang')
       assert.notProperty(lang, 'values', 'no values array added to lang')
     })
   })

--- a/src/models/tests/page-test.html
+++ b/src/models/tests/page-test.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Page Model Tests</title>
+  </head>
+
+  <body>
+    <div id="mocha"></div>
+    <div id="test-area"></div>
+
+    <script src="../../../node_modules/steal/steal.js"
+      data-mocha="bdd"
+      data-main="~/src/models/tests/page-test"></script>
+  </body>
+</html>

--- a/src/models/tests/page-test.js
+++ b/src/models/tests/page-test.js
@@ -1,9 +1,23 @@
 import { assert } from 'chai'
 import Page from '~/src/models/page'
+import DefineMap from 'can-define/map/map'
+import Field from '~/src/models/field'
 
 import 'steal-mocha'
 
 describe('Page Model', function () {
+  it('forces Types', function () {
+    const page = new Page()
+    const step = { name: 'intro', number: '0' }
+    const fields = [{ name: 'foo' }]
+    page.step = step
+    page.fields = fields
+    const isDefineMap = page.step instanceof DefineMap
+    const isFieldList = page.fields instanceof Field.List
+    assert.isTrue(isDefineMap, 'should coerce POJO step to DefineMap')
+    assert.isTrue(isFieldList, 'should coerce POJO fields array to Field.List')
+  })
+
   it('find', function () {
     let page = new Page({
       name: '1-Introduction'
@@ -16,9 +30,9 @@ describe('Page Model', function () {
 
   it('hasUserGenderOrAvatarField - whether page has an "user gender" field', function () {
     let page = new Page({ fields: [{ name: 'Foo Bar' }] })
-    assert.isFalse(page.attr('hasUserGenderOrAvatarField'))
+    assert.isFalse(page.hasUserGenderOrAvatarField)
 
     page = new Page({ fields: [{ name: 'User Gender' }] })
-    assert.isTrue(page.attr('hasUserGenderOrAvatarField'))
+    assert.isTrue(page.hasUserGenderOrAvatarField)
   })
 })

--- a/src/models/tests/tests.js
+++ b/src/models/tests/tests.js
@@ -1,4 +1,5 @@
 import '~/src/models/tests/page-test'
+import '~/src/models/tests/answer-test'
 import '~/src/models/tests/answers-test'
 import '~/src/models/tests/answervm-test'
 import '~/src/models/tests/interview-test'

--- a/src/preview/preview-test.js
+++ b/src/preview/preview-test.js
@@ -11,7 +11,7 @@ describe('<a2j-viewer-preview>', function () {
         // this is parsed to get vars
         window.gGuide = {
           vars: {
-            someVar: { name: 'someVar', values: [null] }
+            someVar: { name: 'someVar', type: 'Text', values: [null] }
           }
         }
         vm = new ViewerPreviewVM({
@@ -36,7 +36,7 @@ describe('<a2j-viewer-preview>', function () {
         // emulate first run or previewInterview clear from Interviews tab
         vm.attr('previewInterview', undefined)
 
-        const expectedAnswerKeys = [ 'lang', 'somevar' ]
+        const expectedAnswerKeys = [ 'somevar' ]
         const previewCleanup = vm.connectedCallback(el)
         const connectedCallbackAnswerKeys = Object.keys(vm.attr('interview.answers')._data)
 
@@ -46,7 +46,7 @@ describe('<a2j-viewer-preview>', function () {
 
       it('restores answers from previewInterview', () => {
         const el = []
-        const expectedAnswerKeys = [ 'lang', 'someAnswer' ]
+        const expectedAnswerKeys = [ 'someAnswer' ]
         const previewCleanup = vm.connectedCallback(el)
         const connectedCallbackAnswerKeys = Object.keys(vm.attr('interview.answers')._data)
 

--- a/src/preview/preview.js
+++ b/src/preview/preview.js
@@ -26,11 +26,11 @@ export const ViewerPreviewVM = CanMap.extend('ViewerPreviewVM', {
     previewInterview: {},
     interviewPageName: {
       get: function () {
-        return this.attr('rState.page')
+        return this.attr('appState.page')
       }
     },
     // set by attr call in connectedCallback
-    rState: {},
+    appState: {},
     pState: {},
     mState: {},
     interview: {},
@@ -42,13 +42,13 @@ export const ViewerPreviewVM = CanMap.extend('ViewerPreviewVM', {
 
   connectedCallback (el) {
     const vm = this
-    const rState = new AppState()
-    const tearDownAppState = rState.connectedCallback(el)
+    const appState = new AppState()
+    const tearDownAppState = appState.connectedCallback(el)
     const mState = new MemoryState()
     const pState = new PersistedState()
 
     // used in Viewer App during previewMode
-    rState.previewActive = true
+    appState.previewActive = true
 
     // if previewInterview.answers exist here, they are restored from Author app-state binding
     const previewAnswers = vm.attr('previewInterview.answers')
@@ -73,34 +73,34 @@ export const ViewerPreviewVM = CanMap.extend('ViewerPreviewVM', {
     answers.attr('lang', lang)
     interview.attr('answers', answers)
 
-    rState.interview = interview
+    appState.interview = interview
 
     // needs to be created after answers are set
     const logic = new Logic({ interview })
-    rState.logic = logic
-    rState.traceMessage = this.traceMessage
+    appState.logic = logic
+    appState.traceMessage = this.traceMessage
 
     // listen for _tLogic trace message events
-    const tLogic = rState.logic._tLogic
+    const tLogic = appState.logic._tLogic
     const tLogicMessageHandler = (ev) => {
-      rState.traceMessage.addMessage(ev.message)
+      appState.traceMessage.addMessage(ev.message)
     }
     tLogic.listenTo('traceMessage', tLogicMessageHandler)
 
     // if previewPageName is set, we need to make sure the viewer
     // loads that specific page (covers the case when user clicks
     // `preview` from the edit page popup).
-    rState.view = 'pages'
+    appState.view = 'pages'
     if (vm.attr('previewPageName')) {
-      rState.set('page', vm.attr('previewPageName'))
+      appState.set('page', vm.attr('previewPageName'))
     } else {
-      rState.set('page', interview.attr('firstPage'))
+      appState.set('page', interview.attr('firstPage'))
     }
 
     const modalContent = compute()
 
     vm.attr({
-      rState,
+      appState,
       pState,
       mState,
       interview,

--- a/src/preview/preview.js
+++ b/src/preview/preview.js
@@ -71,7 +71,7 @@ export const ViewerPreviewVM = CanMap.extend('ViewerPreviewVM', {
       answers.assign(interview.serialize().vars)
     }
 
-    answers.varSet('lang', lang)
+    answers['lang'] = lang
     interview.attr('answers', answers)
 
     appState.interview = interview

--- a/src/preview/preview.js
+++ b/src/preview/preview.js
@@ -1,6 +1,5 @@
 import $ from 'jquery'
 import CanMap from 'can-map'
-import compute from 'can-compute'
 import _assign from 'lodash/assign'
 import Component from 'can-component'
 import isMobile from '~/src/util/is-mobile'
@@ -36,8 +35,7 @@ export const ViewerPreviewVM = CanMap.extend('ViewerPreviewVM', {
     interview: {},
     logic: {},
     lang: {},
-    isMobile: {},
-    modalContent: {}
+    isMobile: {}
   },
 
   connectedCallback (el) {
@@ -98,8 +96,6 @@ export const ViewerPreviewVM = CanMap.extend('ViewerPreviewVM', {
       appState.set('page', interview.attr('firstPage'))
     }
 
-    const modalContent = compute()
-
     vm.attr({
       appState,
       pState,
@@ -107,8 +103,7 @@ export const ViewerPreviewVM = CanMap.extend('ViewerPreviewVM', {
       interview,
       logic,
       lang,
-      isMobile,
-      modalContent
+      isMobile
     })
 
     $(el).html(template(vm))

--- a/src/preview/preview.js
+++ b/src/preview/preview.js
@@ -66,9 +66,9 @@ export const ViewerPreviewVM = CanMap.extend('ViewerPreviewVM', {
 
     if (previewAnswers) { // restore previous answers
       // TODO: allow answers.varSet to take maps/lists
-      answers._answerMap.assign(previewAnswers.serialize())
+      answers.assign(previewAnswers.serialize())
     } else { // just set the interview vars
-      answers._answerMap.assign(interview.serialize().vars)
+      answers.assign(interview.serialize().vars)
     }
 
     answers.varSet('lang', lang)

--- a/src/preview/preview.js
+++ b/src/preview/preview.js
@@ -65,12 +65,13 @@ export const ViewerPreviewVM = CanMap.extend('ViewerPreviewVM', {
     const answers = pState.attr('answers')
 
     if (previewAnswers) { // restore previous answers
-      answers.attr(previewAnswers.serialize())
+      // TODO: allow answers.varSet to take maps/lists
+      answers._answerMap.assign(previewAnswers.serialize())
     } else { // just set the interview vars
-      answers.attr(_assign({}, interview.serialize().vars))
+      answers._answerMap.assign(interview.serialize().vars)
     }
 
-    answers.attr('lang', lang)
+    answers.varSet('lang', lang)
     interview.attr('answers', answers)
 
     appState.interview = interview

--- a/src/util/readable-list.js
+++ b/src/util/readable-list.js
@@ -3,7 +3,7 @@ import _isFunction from 'lodash/isFunction'
 
 // 2014-09-03 Return comma separated, optional 'and' for array.
 export default function readableList (list, lang) {
-  const values = _isFunction(list.attr) ? list.attr() : list
+  const values = _isFunction(list.serialize) ? list.serialize() : list
   const repeatAnd = (lang && lang.RepeatAnd) ? lang.RepeatAnd : 'and'
 
   // Remove null or blanks.

--- a/start-app.js
+++ b/start-app.js
@@ -7,7 +7,6 @@ import constants from '~/src/models/constants'
 import PersistedState from '~/src/models/persisted-state'
 import setMobileDesktopClass from '~/src/util/set-mobile-desktop-class'
 import { analytics } from '~/src/util/analytics'
-import _assign from 'lodash/assign'
 import compute from 'can-compute'
 import route from 'can-route'
 
@@ -23,10 +22,11 @@ export default function ({ interview, pState, mState, appState }) {
   const lang = new Lang(interview.attr('language'))
   const answers = pState.attr('answers')
 
-  answers.attr('lang', lang)
-  answers.attr(_assign({}, interview.serialize().vars))
-  answers.attr(constants.vnInterviewIncompleteTF.toLowerCase(), {
-    name: constants.vnInterviewIncompleteTF.toLowerCase(),
+  answers.lang = lang
+  answers.assign(interview.serialize().vars)
+  const incompleteKey = constants.vnInterviewIncompleteTF.toLowerCase()
+  answers.varSet(incompleteKey, {
+    name: incompleteKey,
     type: constants.vtTF,
     values: [null, true]
   })

--- a/start-app.js
+++ b/start-app.js
@@ -13,7 +13,7 @@ import route from 'can-route'
 
 import '~/src/util/object-assign-polyfill'
 
-export default function ({ interview, pState, mState, rState }) {
+export default function ({ interview, pState, mState, appState }) {
   route.start()
 
   pState = pState || new PersistedState()
@@ -39,20 +39,20 @@ export default function ({ interview, pState, mState, rState }) {
 
   pState.backup()
 
-  rState.bind('change', function (ev, attr, how, val) {
+  appState.bind('change', function (ev, attr, how, val) {
     if (attr === 'page' && val) {
       pState.attr('currentPage', val)
     }
   })
 
-  rState.interview = interview
+  appState.interview = interview
   setMobileDesktopClass(isMobile, $('body'))
 
-  rState.logic = logic
+  appState.logic = logic
 
   // set initial page route
-  rState.view = 'pages'
-  rState.page = interview.attr('firstPage')
+  appState.view = 'pages'
+  appState.page = interview.attr('firstPage')
 
   const modalContent = compute()
 
@@ -61,6 +61,6 @@ export default function ({ interview, pState, mState, rState }) {
   analytics.initialize(authorId)
 
   $('#viewer-app').append(template({
-    rState, pState, mState, interview, logic, lang, isMobile, modalContent
+    appState, pState, mState, interview, logic, lang, isMobile, modalContent
   }))
 }

--- a/start-app.js
+++ b/start-app.js
@@ -7,7 +7,6 @@ import constants from '~/src/models/constants'
 import PersistedState from '~/src/models/persisted-state'
 import setMobileDesktopClass from '~/src/util/set-mobile-desktop-class'
 import { analytics } from '~/src/util/analytics'
-import compute from 'can-compute'
 import route from 'can-route'
 
 import '~/src/util/object-assign-polyfill'
@@ -54,13 +53,11 @@ export default function ({ interview, pState, mState, appState }) {
   appState.view = 'pages'
   appState.page = interview.attr('firstPage')
 
-  const modalContent = compute()
-
   // piwik: set author id for filtering/tracking
   const authorId = interview.authorId || 0
   analytics.initialize(authorId)
 
   $('#viewer-app').append(template({
-    appState, pState, mState, interview, logic, lang, isMobile, modalContent
+    appState, pState, mState, interview, logic, lang, isMobile
   }))
 }


### PR DESCRIPTION
This upgrades the Viewer to use DefineMap and DefineList instead of CanMap/CanList allowing for the new integration of the Author debug-panel locally to the Viewer. This integration is key to adding the Advance Viewer experience, including TOC style navigation and restore a user to their previous spot in an interview. This also paves the way for future feature needs, CanJS upgrades and open source contributions.

closes #76 