### PR TITLE
91 reset modalContent on close handler

### DIFF
--- a/src/modal/modal-test.js
+++ b/src/modal/modal-test.js
@@ -143,5 +143,20 @@ describe('<a2j-modal> ', function () {
 
       assert.isTrue(pauseActivePlayersSpy.calledOnce, 'should fire pauseActivePlayers() on modal close to pause audio and video players')
     })
+
+    it('resets modalContent on close', function () {
+      // simulate DOM insert
+      vm.connectedCallback()
+      vm.modalContent.assign({ title: 'best modal ever' })
+      // open modal
+      $('#pageModal').modal('show')
+
+      assert.equal(vm.modalContent.title, 'best modal ever', 'should clear modalContent props on close')
+
+      // close modal
+      $('#pageModal').modal('hide')
+
+      assert.equal(vm.modalContent.title, '', 'should clear modalContent props on close')
+    })
   })
 })

--- a/src/modal/modal-test.js
+++ b/src/modal/modal-test.js
@@ -151,7 +151,7 @@ describe('<a2j-modal> ', function () {
       // open modal
       $('#pageModal').modal('show')
 
-      assert.equal(vm.modalContent.title, 'best modal ever', 'should clear modalContent props on close')
+      assert.equal(vm.modalContent.title, 'best modal ever', 'should retain modalContent on open')
 
       // close modal
       $('#pageModal').modal('hide')

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -1,6 +1,7 @@
 import $ from 'jquery'
 import DefineMap from 'can-define/map/map'
 import Component from 'can-component'
+import ModalContent from '~/src/models/modal-content'
 import template from './modal.stache'
 import { analytics } from '~/src/util/analytics'
 
@@ -59,6 +60,9 @@ export let ModalVM = DefineMap.extend('ViewerModalVM', {
       const textlongVM = this.modalContent.textlongVM
       textlongVM.fireModalClose(field, newValue, textlongVM)
     }
+
+    // reset modalContent for next use
+    this.appState.modalContent.update(new ModalContent())
 
     $('body').removeClass('bootstrap-styles')
   },


### PR DESCRIPTION
This updates the modalContent on close to prevent lingering textlong values from preventing new modals from opening with their content

closes #91 