### PR TITLE
97 modalContent set in appState, fix tests

### DIFF
--- a/app.stache
+++ b/app.stache
@@ -47,6 +47,7 @@
 
 <a2j-modal
   appState:from="appState"
+  modalContent:from="appState.modalContent"
   mState:from="mState"
   logic:from="logic"
   interview:from="interview"

--- a/src/desktop/steps/steps.js
+++ b/src/desktop/steps/steps.js
@@ -29,11 +29,7 @@ export let ViewerStepsVM = DefineMap.extend('ViewerStepsVM', {
   lang: {},
   logic: {},
   interview: {},
-  modalContent: {
-    get () {
-      return this.appState.modalContent
-    }
-  },
+
   // passed up from pages-stache
   traceMessage: {},
 
@@ -537,7 +533,7 @@ export let ViewerStepsVM = DefineMap.extend('ViewerStepsVM', {
         analytics.trackCustomEvent('Learn-More', 'from: ' + pageName, page.learn)
       }
 
-      this.modalContent.assign({
+      this.appState.modalContent = {
         // name undefined prevents stache warnings
         answerName: undefined,
         title: page.learn,
@@ -548,8 +544,7 @@ export let ViewerStepsVM = DefineMap.extend('ViewerStepsVM', {
         audioURL: page.helpAudioURL,
         videoURL: page.helpVideoURL,
         helpReader: page.helpReader
-      })
-      $('#pageModal').modal('show')
+      }
     }
   },
 

--- a/src/mobile/pages/fields/field/field.js
+++ b/src/mobile/pages/fields/field/field.js
@@ -438,14 +438,13 @@ export const FieldVM = DefineMap.extend('FieldVM', {
       const title = field.label
       const textlongValue = field._answerVm.values
       const textlongVM = this
-      this.modalContent.assign({
+      this.appState.modalContent = {
         title,
         textlongValue,
         answerName,
         field,
         textlongVM
-      })
-      $('#pageModal').modal('show')
+      }
     }
   },
 

--- a/src/mobile/pages/pages-test.js
+++ b/src/mobile/pages/pages-test.js
@@ -136,7 +136,7 @@ describe('<a2j-pages>', () => {
 
         vm.previewActive = true
         vm.navigate(button)
-        const modalContent = vm.modalContent
+        const modalContent = vm.appState.modalContent
 
         assert.equal(modalContent.text, `User's data would upload to the server.`, 'modalContent should update to display modal when previewActive')
       })

--- a/src/mobile/pages/pages-vm.js
+++ b/src/mobile/pages/pages-vm.js
@@ -28,11 +28,6 @@ export default DefineMap.extend('PagesVM', {
   pState: {},
   mState: {},
   interview: {},
-  modalContent: {
-    get () {
-      return this.appState.modalContent
-    }
-  },
   // passed up from fields.js
   groupValidationMap: {},
 
@@ -300,10 +295,10 @@ export default DefineMap.extend('PagesVM', {
     let hasProtocol = failURL.indexOf('http') === 0
     failURL = hasProtocol ? failURL : 'http://' + failURL
     if (failURL === 'http://') { // If Empty, standard message
-      vm.modalContent.assign({
+      vm.appState.modalContent = {
         title: 'You did not Qualify',
         text: 'Unfortunately, you did not qualify to use this A2J Guided Interview. Please close your browser window or tab to exit the interview.'
-      })
+      }
     } else {
       // track the external link
       if (window._paq) {
@@ -389,37 +384,37 @@ export default DefineMap.extend('PagesVM', {
     ev && ev.preventDefault()
     switch (button.next) {
       case constants.qIDFAIL:
-        this.modalContent.assign({
+        this.appState.modalContent = {
           title: 'Author note:',
           text: 'User would be redirected to \n(' + button.url + ')'
-        })
+        }
         break
 
       case constants.qIDEXIT:
-        this.modalContent.assign({
+        this.appState.modalContent = {
           title: 'Author note:',
           text: "User's INCOMPLETE data would upload to the server."
-        })
+        }
         break
 
       case constants.qIDASSEMBLE:
-        this.modalContent.assign({
+        this.appState.modalContent = {
           title: 'Author note:',
           text: 'Document Assembly would happen here.  Use Test Assemble under the Templates tab to assemble in A2J Author'
-        })
+        }
         break
 
       case constants.qIDSUCCESS:
-        this.modalContent.assign({
+        this.appState.modalContent = {
           title: 'Author note:',
           text: "User's data would upload to the server."
-        })
+        }
         break
       case constants.qIDASSEMBLESUCCESS:
-        this.modalContent.assign({
+        this.appState.modalContent = {
           title: 'Author note:',
           text: "User's data would upload to the server, then assemble their document.  Use Test Assemble under the Templates tab to assemble in A2J Author"
-        })
+        }
         break
     }
   },
@@ -435,10 +430,10 @@ export default DefineMap.extend('PagesVM', {
     // This modal and disable is for LHI/HotDocs issue taking too long to process
     // prompting users to repeatedly press submit, crashing HotDocs
     // Matches A2J4 functionality, but should really be handled better on LHI's server
-    vm.modalContent.assign({
+    vm.appState.modalContent = {
       title: 'Answers Submitted :',
       text: 'Page will redirect shortly'
-    })
+    }
 
     if (button.next !== constants.qIDASSEMBLE) {
       vm.dispatch('post-answers-to-server')

--- a/src/mobile/pages/pages.js
+++ b/src/mobile/pages/pages.js
@@ -58,7 +58,7 @@ export default Component.extend({
           analytics.trackCustomEvent('Learn-More', 'from: ' + pageName, page.learn)
         }
 
-        vm.modalContent.assign({
+        vm.appState.modalContent = {
           title: page.learn,
           text: page.help,
           imageURL: page.helpImageURL,
@@ -67,7 +67,7 @@ export default Component.extend({
           audioURL: page.helpAudioURL,
           videoURL: page.helpVideoURL,
           helpReader: page.helpReader
-        })
+        }
       }
     },
 
@@ -89,7 +89,7 @@ export default Component.extend({
 
           // popups only have text, textAudioURL possible values
           // title (page.name) is more of internal descriptor for popups
-          vm.modalContent.assign({
+          vm.appState.modalContent = {
             title: '',
             text: page.text,
             imageURL: undefined,
@@ -98,8 +98,7 @@ export default Component.extend({
             audioURL: page.textAudioURL,
             videoURL: undefined,
             helpReader: undefined
-          })
-          $('#pageModal').modal('show')
+          }
         }
       } else { // external link
         const $el = $(el)

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -16,10 +16,9 @@ export let ModalVM = DefineMap.extend('ViewerModalVM', {
   interview: {},
   appState: {},
 
+  // set in appState and cleared here on close
   modalContent: {
-    get () {
-      return this.appState.modalContent
-    }
+    Type: ModalContent
   },
   repeatVarValue: {
     get () {
@@ -60,9 +59,6 @@ export let ModalVM = DefineMap.extend('ViewerModalVM', {
       const textlongVM = this.modalContent.textlongVM
       textlongVM.fireModalClose(field, newValue, textlongVM)
     }
-
-    // reset modalContent for next use
-    this.appState.modalContent.update(new ModalContent())
 
     $('body').removeClass('bootstrap-styles')
   },
@@ -136,7 +132,7 @@ export default Component.extend({
     '#pageModal keydown': function (el, ev) {
       // esc key closing modal
       if (ev.keyCode === 27) {
-        this.viewModel.modalContent.attr('textlongValue', ev.target.value)
+        this.viewModel.modalContent.textlongValue = ev.target.value
         this.viewModel.closeModalHandler()
       }
     },

--- a/src/models/app-state.js
+++ b/src/models/app-state.js
@@ -5,7 +5,6 @@ import DefineMap from 'can-define/map/map'
 import DefineList from 'can-define/list/list'
 import queues from 'can-queues'
 import TraceMessage from '~/src/models/trace-message'
-import ModalContent from '~/src/models/modal-content'
 
 const UserAvatar = DefineMap.extend('UserAvatar', {
   gender: { default: 'female' },
@@ -124,8 +123,8 @@ export const ViewerAppState = DefineMap.extend('ViewerAppState', {
   },
 
   lastPageBeforeExit: {
-    default: null,
-    serialize: false
+    serialize: false,
+    default: null
   },
 
   lastVisitedPageName: {
@@ -151,10 +150,10 @@ export const ViewerAppState = DefineMap.extend('ViewerAppState', {
     }
   },
 
+  // passed into modal.stache - shows modal on new values
   modalContent: {
     serialize: false,
-    Type: ModalContent,
-    Default: ModalContent
+    default: null
   },
 
   logic: {


### PR DESCRIPTION
This fixes the modal not showing for special buttons/end buttons, but also fixes a larger architecture problem. The modalContent needs to be set and listened to on `appState.modalContent` which triggers the modal to show.

closes #97 