### PR TITLE
underline fix

### DIFF
--- a/src/mobile/pages/pages.less
+++ b/src/mobile/pages/pages.less
@@ -8,6 +8,10 @@ a2j-pages {
     padding: 5px;
     margin-bottom: 15px;
   }
+  
+  .question-text a {
+    text-decoration: underline;
+  }
 
   .btn-navigate {
     margin-bottom: 5px!important;

--- a/src/modal/modal.less
+++ b/src/modal/modal.less
@@ -15,6 +15,10 @@ a2j-modal {
       overflow-y: auto;
     }
 
+    .modal-body a {
+      text-decoration: underline;
+    }
+
     .modal-content {
       .modal-image {
         width: 100%;
@@ -32,7 +36,7 @@ a2j-modal {
         margin-top: 40px;
       }
 
-      .modal-video, {
+      .modal-video {
         box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.15);
       }
 


### PR DESCRIPTION
Fix for ckeditor underline for linked text. Previously, underline was being hidden by inherited styles. 

closes CCALI/author/#169