### PR TITLE
simple happy-path solution to page history restoration

### DIFF
--- a/src/models/constants.js
+++ b/src/models/constants.js
@@ -88,6 +88,9 @@ export default {
   RepeatVarSetOne: '=1',
   RepeatVarSetPlusOne: '+=1',
 
+  // Navigation/Page History for fast-forwarding back to the last viewed page if answers are loaded
+  PAGEHISTORY: 'A2J Visited Pages',
+
   // HotDocs ANX
   // 4/8/04 This is the DTD for the HotDocs ANX file format.
   // It's prepended to the answer set for upload.


### PR DESCRIPTION
... but only works if there were no variant timelines in the page history before saving.

### [do not merge yet]

Will also work as the final solution if any variants get purged from visited page history once a new path is created (which is an option discussed in the past and might be worth consideration again per convo with Mike)

A more complex solution that allows variants is being explored before we make a decision here so the trade-offs will be clear.
(creating this PR now because some of this work is relevant to both directions)