### PR TITLE
replace deprecated matomo function with correct matomo 4 version

### DIFF
--- a/src/util/analytics.js
+++ b/src/util/analytics.js
@@ -56,7 +56,7 @@ function handleHashChanges () {
     var pageName = pageHash ? pageHash.substr(pageHash.indexOf(searchStr) + 5) : 'unnamed page'
     window._paq.push(['setDocumentTitle', hostName + ': ' + pageName])
 
-    window._paq.push(['setGenerationTimeMs', 0])
+    window._paq.push(['setPagePerformanceTiming', 0])
     window._paq.push(['trackPageView'])
   })
 }


### PR DESCRIPTION
Update for matomo 4. fixes #166 and prevents a console error of deprecated function