### PR TITLE
fixes make-viewer-package script

### DIFF
--- a/bin/make-viewer-package
+++ b/bin/make-viewer-package
@@ -57,7 +57,7 @@ function makePackageFolder () {
   fs.copySync(path.join(srcPath, 'README.md'),
     path.join(outputPath, 'README.md'))
   fs.copySync(path.join(srcPath, 'LICENSE.md'),
-    path.join(outputPath, 'License.md'))
+    path.join(outputPath, 'LICENSE.md'))
   fs.copySync(path.join(srcPath, 'Privacy Policy'),
     path.join(outputPath, 'Privacy Policy'))
   fs.copySync(path.join(srcPath, 'A2J Analytics Explanation'),

--- a/bin/make-viewer-package
+++ b/bin/make-viewer-package
@@ -56,7 +56,7 @@ function makePackageFolder () {
   // copy README.md & Legal Info
   fs.copySync(path.join(srcPath, 'README.md'),
     path.join(outputPath, 'README.md'))
-  fs.copySync(path.join(srcPath, 'License.md'),
+  fs.copySync(path.join(srcPath, 'LICENSE.md'),
     path.join(outputPath, 'License.md'))
   fs.copySync(path.join(srcPath, 'Privacy Policy'),
     path.join(outputPath, 'Privacy Policy'))


### PR DESCRIPTION
crashing due to linux case sensitivity on LICENSE.md. This was originally fixed by #118 