### PR TITLE
Fix accessibility issues with the document preview modal

### DIFF
--- a/src/mobile/pages/pages.stache
+++ b/src/mobile/pages/pages.stache
@@ -84,7 +84,7 @@
   {{#if(currentPage.canPreview)}}
     <p>You have documents that can be previewed.</p>
     <button
-      class="btn btn-default btn-navigate open-preview {{#is(button, focusedButton)}}{{focusedButtonRendering()}}{{/is}}"
+      class="btn btn-default btn-navigate open-preview"
       type="button"
     >
        Open document preview 

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -51,6 +51,7 @@ export let ModalVM = DefineMap.extend('ViewerModalVM', {
   },
 
   showTranscript: { default: false },
+  triggeringElement: {},
 
   toggleShowTranscript () {
     this.showTranscript = !this.showTranscript
@@ -66,6 +67,11 @@ export let ModalVM = DefineMap.extend('ViewerModalVM', {
 
   closeModalHandler () {
     $('body').removeClass('bootstrap-styles')
+
+    // Return focus to the element that opened this modal
+    if (this.triggeringElement) {
+      this.triggeringElement.focus()
+    }
   },
 
   pauseActivePlayers () {
@@ -143,6 +149,7 @@ export default Component.extend({
 
     '{viewModel} modalContent': function (vm, ev, newVal) {
       if (newVal) {
+        vm.triggeringElement = document.activeElement
         $(this.element).find('#pageModal').modal()
       }
     },

--- a/src/modal/modal.less
+++ b/src/modal/modal.less
@@ -48,6 +48,17 @@ a2j-modal {
       }
     }
 
+    .modal-header {
+      .close {
+        color: #fff;
+        opacity: 0.7;
+
+        &:focus, &:hover {
+          opacity: 1;
+        }
+      }
+    }
+
     a.zoom-button {
       position: relative;
       margin-top: -30px;


### PR DESCRIPTION
Fixes include:

- When the bubble is first shown, the “open document preview” button does not have focus
- The close buttons in modal headers has more contrast
- Focus goes back to the bubble after closing the modal

Closes https://github.com/CCALI/a2jviewer/issues/180

## Demos

### Close button contrast

![Demo showing the close button contrast](https://user-images.githubusercontent.com/10070176/147431099-c294c8a8-a931-4ec6-84ad-93ca53417c3b.gif)

### Modal focus

![Demo showing the modal focus after closing](https://user-images.githubusercontent.com/10070176/147431108-4f67f81f-f20c-4dd3-b2c7-64c6087c5811.gif)