### PR TITLE
Fix VoiceOver not being able to access modal content

### DIFF
--- a/src/modal/modal.stache
+++ b/src/modal/modal.stache
@@ -5,7 +5,7 @@
     id="pageModal"
     tabindex="-1"
     role="dialog"
-    aria-hidden="true"
+    aria-hidden="{{#if(modalContent)}}false{{else}}true{{/if}}"
     class="modal {{#if(fullscreen)}}maximized{{else}}fade in{{/if}}"
     aria-labelledby="pageModalLbl"
   >


### PR DESCRIPTION
Previously, the modal content was always hidden from screen readers.

Now, the modal content will only be hidden when it’s not set.

Fixes https://github.com/CCALI/a2jviewer/issues/190