### PR TITLE
Fix the styles in the document preview

### DIFF
--- a/src/mobile/pages/pages.js
+++ b/src/mobile/pages/pages.js
@@ -121,7 +121,7 @@ export default Component.extend({
       Preview.findOne(previewData).then(preview => {
         vm.appState.modalContent = {
           title: 'Document preview',
-          text: preview.html,
+          iframeMarkup: preview.html,
           allowFullscreen: true
         }
       }, error => {

--- a/src/modal/modal-test.js
+++ b/src/modal/modal-test.js
@@ -127,6 +127,34 @@ describe('<a2j-modal> ', function () {
       F(done)
     })
 
+    it('renders an iframe if page includes iframeMarkup', function (done) {
+      vm.appState.modalContent = {
+        iframeMarkup: `
+          <!doctype html>
+          <html>
+            <head><title>Example title</title></head>
+            <body>
+              <p class="example">Example paragraph</p>
+            </body>
+          </html>
+        `
+      }
+
+      F(function () {
+        const iframes = document.querySelectorAll('iframe')
+        assert.equal(iframes.length, 1, 'there is only one iframe')
+
+        const titleAttribute = iframes[0].getAttribute('title')
+        assert.equal(titleAttribute, 'Example title', 'the title attribute has the correct text')
+
+        const exampleParagraphs = iframes[0].contentDocument.documentElement.querySelectorAll('p.example')
+        assert.equal(exampleParagraphs.length, 1, 'there is only one example paragraph')
+        assert.equal(exampleParagraphs[0].textContent, 'Example paragraph', 'the paragraph has the correct text')
+      })
+
+      F(done)
+    })
+
     it('targets a new tab (_blank) if question text contains a link', function (done) {
       vm.appState.modalContent = { title: '', text: '<p>My popup text <a href="http://www.google.com">lasercats</a></p>' }
       // prevent the tab from opening

--- a/src/modal/modal.less
+++ b/src/modal/modal.less
@@ -26,6 +26,9 @@ a2j-modal {
           margin: auto;
           padding: 0;
           max-height: ~"calc(100% - 50px)";
+          &.has-iframe {
+            height: ~"calc(100% - 50px)";
+          }
         }
       }
     }
@@ -36,6 +39,13 @@ a2j-modal {
       }
       max-height: 80vh;
       overflow-y: auto;
+
+      &.has-iframe {
+        // Unfortunately the height needs to be set, otherwise the
+        // iframe will only be the min-height set above.
+        height: 80vh;
+        overflow-y: hidden;
+      }
     }
 
     .modal-body a {
@@ -43,6 +53,12 @@ a2j-modal {
     }
 
     .modal-content {
+      .modal-iframe {
+        border: 0;
+        height: 100%;
+        width: 100%;
+      }
+
       .modal-image {
         width: 100%;
         height: auto;

--- a/src/modal/modal.stache
+++ b/src/modal/modal.stache
@@ -1,3 +1,4 @@
+<can-import from="~/src/util/iframemarkup-attr.js"/>
 <can-import from='~/src/modal/modal.less' />
 <can-import from='~/src/audio-player/' />
 
@@ -45,7 +46,7 @@
           </h4>
         </div>
 
-        <div class="modal-body {{#if(modalContent.textlongFieldVM.field.name)}}has-textarea{{/if}}" tabindex="1">
+        <div class="modal-body {{#if(modalContent.iframeMarkup)}}has-iframe{{/if}} {{#if(modalContent.textlongFieldVM.field.name)}}has-textarea{{/if}}" tabindex="1">
           {{#if(modalContent.textlongFieldVM.field.name)}}
             <textarea autofocus
               id="textlong-input"
@@ -56,7 +57,11 @@
               {{> exceeded-maxchars-tpl}}
             {{/if}}
           {{else}}
-            {{{insertExternalLinkIcon(parseText(modalContent.text))}}}
+            {{#if(modalContent.iframeMarkup)}}
+              <iframe class="modal-iframe" iframemarkup="modalContent.iframeMarkup"></iframe>
+            {{else}}
+              {{{insertExternalLinkIcon(parseText(modalContent.text))}}}
+            {{/if}}
 
             {{#if(modalContent.audioURL)}}
               <div class="modal-audio-wrapper">

--- a/src/util/iframemarkup-attr.js
+++ b/src/util/iframemarkup-attr.js
@@ -1,0 +1,21 @@
+import canViewCallbacks from 'can-view-callbacks'
+
+canViewCallbacks.attr('iframemarkup', function (element, attrData) {
+  const scopePath = element.getAttribute(attrData.attributeName)
+  const markup = attrData.scope.get(scopePath)
+
+  // The delay is required because element.contentWindow.document
+  // is not available until the iframe is in the DOM.
+  setTimeout(() => {
+    const frameDocument = element.contentWindow.document
+    frameDocument.open()
+    frameDocument.write(markup)
+    frameDocument.close()
+
+    // Set the title
+    const titleElement = frameDocument.querySelector('title')
+    if (titleElement && titleElement.textContent) {
+      element.setAttribute('title', titleElement.textContent)
+    }
+  }, 0)
+})


### PR DESCRIPTION
Previously, the styles from the app affected what’s in the document preview, so it wasn’t true to what the generated PDF would look like.

This is now resolved by inserting the document preview into its own `iframe`, where styles from the app won’t affect the preview HTML.

Fixes https://github.com/CCALI/a2jviewer/issues/181
Fixes https://github.com/CCALI/a2jviewer/issues/192

## Previous

<img width="614" alt="Screen Shot 2021-12-29 at 4 05 18 AM" src="https://user-images.githubusercontent.com/10070176/147668125-543b8d10-ee0b-42f3-abab-0b0ac44c05db.png">

## Fixed

<img width="610" alt="Screen Shot 2021-12-29 at 4 42 30 AM" src="https://user-images.githubusercontent.com/10070176/147668140-7d08f7b9-ca55-41ed-bb48-f477afa3f78d.png">