### PR TITLE
fix npm release footer version update flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,11 +14,12 @@
     "update-footer-version": "node ./bin/auto-version-update",
     "git-commit": "git commit -am 'Update footerVersion'",
     "preversion": "npm run test",
+    "version": "npm run update-footer-version",
     "release:pre": "npm version prerelease && npm publish --tag=pre",
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish",
-    "postpublish": "npm run update-footer-version && npm run git-commit && git push --tags && git push"
+    "postpublish": "npm run git-commit && git push --tags && git push"
   },
   "author": {
     "name": "Center for Computer-Assisted Legal Instruction (CALI)",


### PR DESCRIPTION
this fixes the auto update to the footerVersion.js flow to capture the correct npm published version from package.json, but also commit and push the footerVersion.js file changes to the local branch.

@tobiasnteireho 