### PR TITLE
add min/max ranges to proper fields

### DIFF
--- a/index.dev.html
+++ b/index.dev.html
@@ -59,6 +59,6 @@
           errRepURL: ''
         }));
       </script>
-      <script src="node_modules/steal/steal.production.js?v=1733872401300" cache-key="v" cache-version="1733872401300" main="@caliorg/a2jviewer/app"></script>
+      <script src="node_modules/steal/steal.production.js?v=1733928463964" cache-key="v" cache-version="1733928463964" main="@caliorg/a2jviewer/app"></script>
     </body>
   </html>

--- a/index.dev.html
+++ b/index.dev.html
@@ -59,6 +59,6 @@
           errRepURL: ''
         }));
       </script>
-      <script src="node_modules/steal/steal.production.js?v=1733928463964" cache-key="v" cache-version="1733928463964" main="@caliorg/a2jviewer/app"></script>
+      <script src="node_modules/steal/steal.production.js?v=1738596676504" cache-key="v" cache-version="1738596676504" main="@caliorg/a2jviewer/app"></script>
     </body>
   </html>

--- a/index.html
+++ b/index.html
@@ -59,6 +59,6 @@
           errRepURL: ''
         }));
       </script>
-      <script src="node_modules/steal/steal.production.js?v=1738596676504" cache-key="v" cache-version="1738596676504" main="@caliorg/a2jviewer/app"></script>
+      <script src="node_modules/steal/steal.production.js?v=1739423482585" cache-key="v" cache-version="1739423482585" main="@caliorg/a2jviewer/app"></script>
     </body>
   </html>

--- a/index.html
+++ b/index.html
@@ -59,6 +59,6 @@
           errRepURL: ''
         }));
       </script>
-      <script src="node_modules/steal/steal.production.js?v=1733928463964" cache-key="v" cache-version="1733928463964" main="@caliorg/a2jviewer/app"></script>
+      <script src="node_modules/steal/steal.production.js?v=1738596676504" cache-key="v" cache-version="1738596676504" main="@caliorg/a2jviewer/app"></script>
     </body>
   </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@caliorg/a2jviewer",
-  "version": "8.4.1-0",
+  "version": "8.4.1-1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@caliorg/a2jviewer",
-      "version": "8.4.1-0",
+      "version": "8.4.1-1",
       "license": "GNU AGPL v3.0",
       "dependencies": {
         "@caliorg/a2jdeps": "^7.1.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@caliorg/a2jviewer",
-  "version": "8.4.0",
+  "version": "8.4.1-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@caliorg/a2jviewer",
-      "version": "8.4.0",
+      "version": "8.4.1-0",
       "license": "GNU AGPL v3.0",
       "dependencies": {
         "@caliorg/a2jdeps": "^7.1.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@caliorg/a2jviewer",
-  "version": "8.4.1-1",
+  "version": "8.4.1-2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@caliorg/a2jviewer",
-      "version": "8.4.1-1",
+      "version": "8.4.1-2",
       "license": "GNU AGPL v3.0",
       "dependencies": {
         "@caliorg/a2jdeps": "^7.1.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@caliorg/a2jviewer",
-  "version": "8.4.1-2",
+  "version": "8.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@caliorg/a2jviewer",
-      "version": "8.4.1-2",
+      "version": "8.4.1",
       "license": "GNU AGPL v3.0",
       "dependencies": {
         "@caliorg/a2jdeps": "^7.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caliorg/a2jviewer",
-  "version": "8.4.1-0",
+  "version": "8.4.1-1",
   "description": "A2J Viewer standalone and preview app.",
   "main": "a2jviewer/app",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caliorg/a2jviewer",
-  "version": "8.4.1-1",
+  "version": "8.4.1-2",
   "description": "A2J Viewer standalone and preview app.",
   "main": "a2jviewer/app",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caliorg/a2jviewer",
-  "version": "8.4.1-2",
+  "version": "8.4.1",
   "description": "A2J Viewer standalone and preview app.",
   "main": "a2jviewer/app",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caliorg/a2jviewer",
-  "version": "8.4.0",
+  "version": "8.4.1-0",
   "description": "A2J Viewer standalone and preview app.",
   "main": "a2jviewer/app",
   "scripts": {

--- a/src/footer/footerVersion.js
+++ b/src/footer/footerVersion.js
@@ -1,7 +1,7 @@
 
 const version = {
-  number: '8.4.1-2',
-  date: '2025-02-03'
+  number: '8.4.1',
+  date: '2025-02-13'
 }
 
 export default version

--- a/src/footer/footerVersion.js
+++ b/src/footer/footerVersion.js
@@ -1,6 +1,6 @@
 
 const version = {
-  number: '8.4.1-0',
+  number: '8.4.1-2',
   date: '2025-02-03'
 }
 

--- a/src/footer/footerVersion.js
+++ b/src/footer/footerVersion.js
@@ -1,7 +1,7 @@
 
 const version = {
-  number: '8.4.0',
-  date: '2024-12-11'
+  number: '8.4.1-0',
+  date: '2025-02-03'
 }
 
 export default version

--- a/src/mobile/pages/fields/field/field.js
+++ b/src/mobile/pages/fields/field/field.js
@@ -173,6 +173,14 @@ export const FieldVM = DefineMap.extend('FieldVM', {
     get () {
       const min = this.field.min || 'any'
       const max = this.field.max || 'any'
+      const isDateMDY = this.field.type === 'datemdy'
+
+      if (isDateMDY) {
+        let minDate = moment(min, 'MMDDYYYY').format('MM/DD/YYYY')
+        let maxDate = moment(max, 'MMDDYYYY').format('MM/DD/YYYY')
+        return `(${minDate} ~~~ ${maxDate})`
+      }
+      
       return `(${min} ~~~ ${max})`
     }
   },

--- a/src/mobile/pages/fields/field/field.js
+++ b/src/mobile/pages/fields/field/field.js
@@ -180,7 +180,7 @@ export const FieldVM = DefineMap.extend('FieldVM', {
         let maxDate = moment(max, 'MMDDYYYY').format('MM/DD/YYYY')
         return `(${minDate} ~~~ ${maxDate})`
       }
-      
+
       return `(${min} ~~~ ${max})`
     }
   },

--- a/src/mobile/pages/fields/field/views/datemdy.stache
+++ b/src/mobile/pages/fields/field/views/datemdy.stache
@@ -8,15 +8,13 @@
       {{#if(field.required)}}<small class="text-danger">({{lang.Required}})</small>{{/if}}
     </label>
     <div class="datepicker-field-field">
-      <input
-        type="text"
-        id:from="this.idFromLabelHTML(field.label)"
-        name="{{field.name}}"
-        value:bind="field._answerVm.textValue"
-        on:change="validateField(null, scope.element)"
-        {{#if(field.required)}}required{{/if}}
-        class="form-control datepicker-input" />
+      <input type="text" id:from="this.idFromLabelHTML(field.label)" name="{{field.name}}"
+        value:bind="field._answerVm.textValue" on:change="validateField(null, scope.element)"
+        {{#if(field.required)}}required{{/if}} class="form-control datepicker-input" />
     </div>
+    {{#if(showMinMaxPrompt)}}
+    {{minMaxPrompt}}
+    {{/if}}
   </div>
 
   {{> invalid-prompt-tpl }}

--- a/src/mobile/pages/fields/field/views/invalid-prompt.stache
+++ b/src/mobile/pages/fields/field/views/invalid-prompt.stache
@@ -1,10 +1,7 @@
 {{#if(showInvalidPrompt)}}
-  <div class="alert alert-danger" role="alert">
-    <span class="glyphicon-attention" aria-hidden="true">
-        {{{ parseText(scope.vm.invalidPrompt) }}}
-        {{#if(showMinMaxPrompt)}}
-            {{minMaxPrompt}}
-        {{/if}}
-    </span>
-  </div>
+<div class="alert alert-danger" role="alert">
+  <span class="glyphicon-attention" aria-hidden="true">
+    {{{ parseText(scope.vm.invalidPrompt) }}}
+  </span>
+</div>
 {{/if}}

--- a/src/mobile/pages/fields/field/views/number.stache
+++ b/src/mobile/pages/fields/field/views/number.stache
@@ -7,26 +7,19 @@
       {{#if(field.required)}}<small class="text-danger">({{lang.Required}})</small>{{/if}}
     </label>
     <div class="number-field">
-      <input
-        type="text"
-        inputmode="decimal"
-        id="{{idFromLabelHTML(field.label)}}"
-        name="{{field.name}}"
-        {{#if(field.required)}}required{{/if}}
-        class="form-control"
-        on:input="preValidateNumber(null, scope.element)"
-        on:change="validateField(null, scope.element)"
-        value:bind="field._answerVm.textValue"/>
-        {{#if(field.calculator)}}
-          <button
-            aria-label="Expand Calculator"
-            class="btn btn-default expand-calc pull-right"
-            on:click="showCalculator(field)"
-            aui-action="open">
-            <span class="icon calc-icon glyphicon-calc" aria-hidden="true"></span>
-          </button>
-        {{/if}}
+      <input type="text" inputmode="decimal" id="{{idFromLabelHTML(field.label)}}" name="{{field.name}}"
+        {{#if(field.required)}}required{{/if}} class="form-control" on:input="preValidateNumber(null, scope.element)"
+        on:change="validateField(null, scope.element)" value:bind="field._answerVm.textValue" />
+      {{#if(field.calculator)}}
+      <button aria-label="Expand Calculator" class="btn btn-default expand-calc pull-right"
+        on:click="showCalculator(field)" aui-action="open">
+        <span class="icon calc-icon glyphicon-calc" aria-hidden="true"></span>
+      </button>
+      {{/if}}
     </div>
+    {{#if(showMinMaxPrompt)}}
+    {{minMaxPrompt}}
+    {{/if}}
   </div>
   {{> invalid-prompt-tpl }}
 </div>

--- a/src/mobile/pages/fields/field/views/numberdollar.stache
+++ b/src/mobile/pages/fields/field/views/numberdollar.stache
@@ -9,26 +9,19 @@
 
     <div class="numberdollar-field">
       <span>$</span>
-      <input
-        type="text"
-        inputmode="decimal"
-        id="{{idFromLabelHTML(field.label)}}"
-        name="{{field.name}}"
-        {{#if(field.required)}}required{{/if}}
-        class="form-control"
-        on:input="preValidateNumber(null, scope.element)"
-        on:change="validateField(null, scope.element)"
-        value:bind="field._answerVm.values"/>
-        {{#if(field.calculator)}}
-          <button
-            aria-label="Expand Calculator"
-            class="btn btn-default expand-calc pull-right"
-            on:click="showCalculator(field)"
-            aui-action="open">
-            <span class="icon calc-icon glyphicon-calc" aria-hidden="true"></span>
-          </button>
-        {{/if}}
+      <input type="text" inputmode="decimal" id="{{idFromLabelHTML(field.label)}}" name="{{field.name}}"
+        {{#if(field.required)}}required{{/if}} class="form-control" on:input="preValidateNumber(null, scope.element)"
+        on:change="validateField(null, scope.element)" value:bind="field._answerVm.values" />
+      {{#if(field.calculator)}}
+      <button aria-label="Expand Calculator" class="btn btn-default expand-calc pull-right"
+        on:click="showCalculator(field)" aui-action="open">
+        <span class="icon calc-icon glyphicon-calc" aria-hidden="true"></span>
+      </button>
+      {{/if}}
     </div>
+    {{#if(showMinMaxPrompt)}}
+    {{minMaxPrompt}}
+    {{/if}}
   </div>
 
   {{> invalid-prompt-tpl }}


### PR DESCRIPTION
this shows the expected ranges for number, number-dollar, and date fields that have a min/max set. number-list does not require to show the range as the selector already enforces the min/max.

related to https://github.com/CCALI/a2jauthor/pull/421