### PR TITLE
handle TODAY display in date ranges

### DIFF
--- a/src/mobile/pages/fields/field/field.js
+++ b/src/mobile/pages/fields/field/field.js
@@ -176,8 +176,8 @@ export const FieldVM = DefineMap.extend('FieldVM', {
       const isDateMDY = this.field.type === 'datemdy'
 
       if (isDateMDY) {
-        let minDate = moment(min, 'MMDDYYYY').format('MM/DD/YYYY')
-        let maxDate = moment(max, 'MMDDYYYY').format('MM/DD/YYYY')
+        let minDate = min === 'TODAY' ? moment().format('MM/DD/YYYY') : moment(min, 'MMDDYYYY').format('MM/DD/YYYY')
+        let maxDate = max === 'TODAY' ? moment().format('MM/DD/YYYY') : moment(max, 'MMDDYYYY').format('MM/DD/YYYY')
         return `(${minDate} ~~~ ${maxDate})`
       }
 


### PR DESCRIPTION
this fixes a bug where a date range was showing `invalid date` when using the TODAY keyword as a min or max on a date field. Now it will display today's date correctly.