### PR TITLE
Autosave on continue button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,9 @@ stylecop.*
 *.dbmdl
 Generated_Code #added for RIA/Silverlight projects
 dist/
+dist_local/
+/scripts/viewer/index.html
+/scripts/guides/default/
 userfiles
 
 # Backup & report files from converting an old project file to a newer

--- a/README.md
+++ b/README.md
@@ -78,6 +78,27 @@ run the command below in a terminal
 
 This will build a zip in the parent folder of the cloned repo with the naming patern a2j-viewer_{MAJVER}.{MINVER}.{PATCH}_{YYYY}-{MM}-{DD}.zip
 
+## Local Development & Testing
+
+If you need to modify the A2J Viewer source or test it within a local environment, follow the steps below.
+
+### 1. Configuration of Interview Files
+Before running the local development server, ensure your interview/guide files are placed in the following directory:
+`scripts/guides/default/`
+
+> **Note:** If this directory is empty, the viewer will fallback to the default sample guides located in the `demo` folder.
+
+### 2. Launching the Development Server
+To initiate the local build process and start the web server, execute the following command in your terminal:
+
+```bash
+npm run dev
+```
+
+### 3. Workflow Limitations (No HMR)
+Please be advised that Hot Module Replacement (HMR) is currently *not supported*.
+To reflect any changes made to the local source files (JS, LESS, or HTML), you must stop the current process and re-run the `npm run dev` command to rebuild the assets.
+
 ## Upgrading
 1.) backup your old viewer and Guided Interviews
 

--- a/demo/build.viewer.html.js
+++ b/demo/build.viewer.html.js
@@ -5,6 +5,7 @@ const path = require('path')
 const buildViewerHtml = function (isLocal = false) {
   const version = Date.now()
   const templatePath = isLocal ? '.' : '..'
+  const setDataURL = isLocal ? './answers' : './answers.php'
   const html = template(version, templatePath)
 
   function template (version, templatePath) {
@@ -42,7 +43,7 @@ const buildViewerHtml = function (isLocal = false) {
           getDataURL: '',
 
           // endpoint to save the answer's file and leaves the viewer (its response replaces viewer's frame)
-          setDataURL: './answers.php',
+          setDataURL: '${setDataURL}',
 
           // (Optional) ajax endpoint to silently save the answer file periodically
           autoSetDataURL: '',

--- a/demo/build.viewer.html.js
+++ b/demo/build.viewer.html.js
@@ -2,11 +2,12 @@
 const fs = require('fs')
 const path = require('path')
 
-const buildViewerHtml = function () {
+const buildViewerHtml = function (isLocal = false) {
   const version = Date.now()
-  const html = template(version)
+  const templatePath = isLocal ? '.' : '..'
+  const html = template(version, templatePath)
 
-  function template (version) {
+  function template (version, templatePath) {
     return `<!--
     A2J Author 7 * Justice * justicia * 正义 * công lý * 사법 * правосудие
     All Contents Copyright The Center for Computer-Assisted Legal Instruction
@@ -31,11 +32,11 @@ const buildViewerHtml = function () {
       <script>
         localStorage.setItem('a2jConfig', JSON.stringify({
           // path (or url) to the interview XML file
-          templateURL: '../guides/default/Guide.xml',
+          templateURL: '${templatePath}/guides/default/Guide.xml',
 
           // folder containing images, templates and other assets related to the interview
           // path can be relative or fully qualified but requires a trailing slash
-          fileDataURL: '../guides/default/',
+          fileDataURL: '${templatePath}/guides/default/',
 
           // endpoint to load an answer file at start, used for RESUME
           getDataURL: '',
@@ -71,7 +72,18 @@ const buildViewerHtml = function () {
   </html>`
   }
 
-  fs.writeFileSync(path.join(__dirname, '/viewer/viewer.html'), html, 'utf-8')
+  if (isLocal) {
+    const outputPath = path.join(__dirname, '../scripts/viewer/index.html')
+    const dirPath = path.dirname(outputPath)
+
+    // check folder exists, if not create it
+    if (!fs.existsSync(dirPath)) {
+      fs.mkdirSync(dirPath, { recursive: true })
+    }
+    fs.writeFileSync(outputPath, html, 'utf-8')
+  } else {
+    fs.writeFileSync(path.join(__dirname, '/viewer/viewer.html'), html, 'utf-8')
+  }
 }
 
 module.exports = {

--- a/index.dev.html
+++ b/index.dev.html
@@ -27,7 +27,7 @@
     </head>
 
     <body>
-      <div id="viewer-app"></div>
+      <div id="viewer-app-container"></div>
 
       <script> window.less = { async: true, useFileCache: true };</script>
       <script>
@@ -59,6 +59,6 @@
           errRepURL: ''
         }));
       </script>
-      <script src="node_modules/steal/steal.production.js?v=1785976641464" cache-key="v" cache-version="1785976641464" main="@caliorg/a2jviewer/app"></script>
+      <script src="node_modules/steal/steal.js" cache-key="v" cache-version="1739423482585" main="@caliorg/a2jviewer/app"></script>
     </body>
   </html>

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "a2jviewer/app",
   "scripts": {
     "lint": "standard --fix --env mocha",
+    "dev": "node scripts/build.local.js npx http-server dist_local && npx http-server dist_local",
     "test": "npm run lint && testee --reporter Spec --browsers firefox tests/index.html",
     "build": "grunt build --gruntfile=Gruntfile.js",
     "deploy": "npm i && npm run build && mv index.html index.dev.html && mv index.production.html index.html",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "a2jviewer/app",
   "scripts": {
     "lint": "standard --fix --env mocha",
-    "dev": "node scripts/build.local.js npx http-server dist_local && npx http-server dist_local",
+    "dev": "node scripts/build.local.js && node dist_local/server.js",
     "test": "npm run lint && testee --reporter Spec --browsers firefox tests/index.html",
     "build": "grunt build --gruntfile=Gruntfile.js",
     "deploy": "npm i && npm run build && mv index.html index.dev.html && mv index.production.html index.html",

--- a/scripts/build.local.js
+++ b/scripts/build.local.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+
+const path = require('path')
+const fs = require('fs-extra')
+const chalk = require('chalk')
+const stealTools = require('steal-tools')
+const { buildViewerHtml } = require('../demo/build.viewer.html')
+
+const srcPath = path.join(__dirname, '..')
+const outputPath = path.join(srcPath, 'dist_local')
+
+console.log(chalk.cyan('🚀 Starting Optimized Local Build...'))
+
+const buildConfig = {
+  main: 'app',
+  config: path.join(srcPath, 'package.json!npm')
+}
+
+const buildOptions = {
+  minify: true,
+  bundleSteal: true,
+  dest: path.join(outputPath, 'dist')
+}
+
+// 1. Clean up previous build results
+fs.removeSync(outputPath)
+
+// 2. Execute StealJS Build
+stealTools.build(buildConfig, buildOptions)
+  .then(function () {
+    console.log(chalk.yellow('📦 JS Build finished. Syncing static assets...'))
+    makePackageFolder()
+    console.log(chalk.green('✨ Build Complete! Assets are located in: ' + outputPath))
+    console.log(chalk.blue('🔗 Command: npx http-server dist_local'))
+  })
+  .catch(function (error) {
+    console.log(chalk.red('❌ Build failed!'))
+    throw error
+  })
+
+/**
+ * Orchestrates the copying of all necessary static files into the distribution folder.
+ */
+function makePackageFolder () {
+  // Ensure the output directory exists
+  fs.ensureDirSync(outputPath)
+
+  // Generate the shell HTML (local_viewer.html) using the imported utility
+  buildViewerHtml(true)
+
+  // Copy interview-specific guides and default content
+  fs.copySync(path.join(srcPath, 'demo/guides/default/'), path.join(outputPath, 'guides', 'default'))
+
+  // Copy viewer-related templates and static assets
+  fs.copySync(path.join(srcPath, 'scripts/viewer/'), outputPath)
+
+  // Copy global styles and generic images
+  fs.copySync(path.join(srcPath, 'styles', 'viewer-avatars.css'), path.join(outputPath, 'styles', 'viewer-avatars.css'))
+  fs.copySync(path.join(srcPath, 'images'), path.join(outputPath, 'images'))
+
+  // Ensure the default guide folder exists in the source for local development
+  fs.ensureDirSync(path.join(srcPath, 'scripts/guides/default/'))
+  fs.copySync(path.join(srcPath, 'scripts/guides/default/'), path.join(outputPath, 'guides', 'default'))
+
+  // Sync dependency assets: Avatar images from @caliorg
+  const depsPath = path.join(srcPath, 'node_modules', '@caliorg', 'a2jdeps', 'avatar', 'images')
+  if (fs.existsSync(depsPath)) {
+    fs.copySync(depsPath, path.join(outputPath, 'node_modules', '@caliorg', 'a2jdeps', 'avatar', 'images'))
+  }
+
+  // Sync dependency assets: Lightbox2 UI elements
+  const lbPath = path.join(srcPath, 'node_modules', 'lightbox2', 'dist', 'images')
+  if (fs.existsSync(lbPath)) {
+    fs.copySync(lbPath, path.join(outputPath, 'node_modules', 'lightbox2', 'dist', 'images'))
+  }
+
+  console.log(chalk.yellow('✅ All static assets successfully merged into dist_local.'))
+}

--- a/scripts/viewer/server.js
+++ b/scripts/viewer/server.js
@@ -1,0 +1,106 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const querystring = require('querystring');
+
+const PORT = 8080;
+
+const server = http.createServer((req, res) => {
+  // ----------------------------------------------------
+  // 1. [ROUTING] Handle Auto-Save POST Request
+  // ----------------------------------------------------
+  if (req.method === 'POST' && req.url === '/answers') {
+    let body = '';
+    
+    req.on('data', chunk => { body += chunk.toString(); });
+    
+    req.on('end', () => {
+      const postData = querystring.parse(body);
+      const answerKey = postData.AnswerKey || '';
+      const answerKeyJSON = postData.AnswerKeyJSON || '';
+      const timestamp = new Date().toLocaleTimeString();
+
+      // [CONSOLE LOGS]
+      console.log('\n==================================================');
+      console.log(`[${timestamp}] 📥 Auto Save (AJAX) -> /answers received!`);
+      console.log('==================================================');
+      console.log(`- AnswerKey Length: ${answerKey.length} chars`);
+      console.log(`- AnswerKeyJSON Length: ${answerKeyJSON.length} chars`);
+      console.log('--------------------------------------------------');
+
+      // [FILE SAVING]
+      try {
+        if (answerKey) {
+          fs.writeFileSync('./debug_AnswerKey.xml', answerKey, 'utf-8');
+          console.log(`- [File Saved] debug_AnswerKey.xml completed`);
+        }
+        if (answerKeyJSON) {
+          let formattedJson = answerKeyJSON;
+          try {
+            // Pretty-print JSON for better readability
+            formattedJson = JSON.stringify(JSON.parse(answerKeyJSON), null, 2);
+          } catch (e) {}
+          fs.writeFileSync('./debug_AnswerKey.json', formattedJson, 'utf-8');
+          console.log(`- [File Saved] debug_AnswerKey.json completed`);
+        }
+      } catch (fileError) {
+        console.error(`- ❌ File Write Error:`, fileError.message);
+      }
+      console.log('==================================================\n');
+
+      // Send success response back to A2J Viewer
+      res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
+      res.end(JSON.stringify({ ok: true, message: 'Saved successfully.' }));
+    });
+    return;
+  }
+
+  // ----------------------------------------------------
+  // 2. [STATIC SERVING] Replace npx http-server dist_local
+  // ----------------------------------------------------
+  if (req.method === 'GET') {
+    console.log('req.url', req.url);
+    // Resolve URL path (default to index.html)
+    let safeUrl = req.url === '/' ? '/index.html' : req.url;
+    // Strip query strings if present (e.g., ?v=1.0)
+    safeUrl = safeUrl.split('?')[0];
+    
+    const filePath = path.join(__dirname, safeUrl);
+
+    // Content-Type mapping for static files
+    const ext = path.extname(filePath).toLowerCase();
+    const mimeTypes = {
+      '.html': 'text/html; charset=utf-8',
+      '.js': 'text/javascript; charset=utf-8',
+      '.css': 'text/css; charset=utf-8',
+      '.json': 'application/json; charset=utf-8',
+      '.png': 'image/png',
+      '.jpg': 'image/jpeg',
+      '.gif': 'image/gif',
+      '.svg': 'image/svg+xml'
+    };
+    const contentType = mimeTypes[ext] || 'application/octet-stream';
+
+    // Read and serve the file
+    fs.readFile(filePath, (error, content) => {
+      if (error) {
+        if (error.code === 'ENOENT') {
+          res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+          res.end('404 Not Found - File does not exist.');
+        } else {
+          res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
+          res.end(`500 Server Error: ${error.code}`);
+        }
+      } else {
+        res.writeHead(200, { 'Content-Type': contentType });
+        res.end(content, 'utf-8');
+      }
+    });
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`🚀 Pure Node.js Server is running on http://localhost:${PORT}`);
+  console.log(`💻 Open your browser at: http://localhost:${PORT}`);
+  console.log(`📝 Set A2J Viewer's setDataURL to: "/answers"\n`);
+});

--- a/src/desktop/navigation/navigation.js
+++ b/src/desktop/navigation/navigation.js
@@ -118,6 +118,25 @@ export let ViewerNavigationVM = DefineMap.extend({
   },
 
   /**
+   * @property {Function} viewerNavigation.ViewModel.saveOnly saveOnly
+   * @parent viewerNavigation.ViewModel
+   *
+   * Saves interview and exits.
+   */
+  saveOnly () {
+    const answers = this.interview.attr('answers')
+    const pageName = this.appState.page
+
+    if (window._paq) {
+      analytics.trackCustomEvent('Save', 'from: ' + pageName)
+    }
+
+    if (answers) {
+      answers.varSet('a2j interview incomplete tf', true, 1)
+    }
+  },
+
+  /**
    * @property {Function} viewerNavigation.ViewModel.resumeInterview resumeInterview
    * @parent viewerNavigation.ViewModel
    *
@@ -167,6 +186,12 @@ export default Component.extend({
       let feedbackData = this.feedbackData
       let baseUrl = 'http://www.a2jauthor.org/A2JFeedbackForm.php?'
       return baseUrl + $.param(feedbackData)
+    }
+  },
+
+  events: {
+    '{appState} saveOnly': function () {
+      this.viewModel.saveOnly()
     }
   }
 })

--- a/src/mobile/pages/pages-test.js
+++ b/src/mobile/pages/pages-test.js
@@ -152,6 +152,34 @@ describe('<a2j-pages>', () => {
         assert.equal(postCount, 1, 'should not fire post for assemble only')
       })
 
+      it('saveAnswersToServerAsync coalesces overlapping saves', function (done) {
+        const clock = sinon.useFakeTimers()
+        const ajaxStub = sinon.stub($, 'ajax').callsFake(function () {
+          return {
+            always (callback) {
+              callback()
+              return this
+            }
+          }
+        })
+
+        vm.pState = new PersistedState({ setDataURL: 'https://example.org/save.php' })
+
+        vm.saveAnswersToServerAsync()
+        vm.saveAnswersToServerAsync()
+        vm.saveAnswersToServerAsync()
+
+        clock.tick(500)
+        assert.equal(ajaxStub.callCount, 1, 'should only POST once while first request is in flight')
+
+        clock.tick(500)
+        assert.equal(ajaxStub.callCount, 2, 'should POST again with latest answers after first completes')
+
+        ajaxStub.restore()
+        clock.restore()
+        done()
+      })
+
       it('getNextPage - check for normal nav or GOTO logic', () => {
         const button = new DefineMap({ next: 'foo' })
         const currentPage = vm.currentPage

--- a/src/mobile/pages/pages-vm.js
+++ b/src/mobile/pages/pages-vm.js
@@ -771,6 +771,58 @@ export default DefineMap.extend('PagesVM', {
     }
   },
 
+  /**
+   * POST current answers to `setDataURL` without redirecting the page.
+   * Used when the user clicks Continue to save progress in the background.
+   * Overlapping requests are coalesced so only one POST runs at a time and
+   * the latest answers are always sent after the in-flight request completes.
+   */
+  saveAnswersToServerAsync () {
+    if (this.previewActive) { return }
+
+    const setDataURL = this.pState && this.pState.setDataURL
+    if (!setDataURL) { return }
+
+    this._saveAnswersPending = true
+
+    if (this._saveAnswersInFlight) {
+      return
+    }
+
+    this._flushSaveAnswersToServer()
+  },
+
+  _flushSaveAnswersToServer () {
+    if (!this._saveAnswersPending) { return }
+
+    this._saveAnswersPending = false
+    this._saveAnswersInFlight = true
+
+    if (this._saveAnswersTimeout) {
+      clearTimeout(this._saveAnswersTimeout)
+    }
+
+    const vm = this
+    this._saveAnswersTimeout = setTimeout(function () {
+      const data = {
+        AnswerKey: vm.answersANX,
+        fileDataUrl: vm.mState.fileDataURL,
+        AnswerKeyJSON: vm.answersJSON
+      }
+
+      $.ajax({
+        url: vm.pState.setDataURL,
+        type: 'POST',
+        data: data
+      }).always(function () {
+        vm._saveAnswersInFlight = false
+        if (vm._saveAnswersPending) {
+          vm._flushSaveAnswersToServer()
+        }
+      })
+    }, 500)
+  },
+
   handleServerPost (button, vm, previewActive, ev) {
     // do nothing if in preview
     if (previewActive) { return }

--- a/src/mobile/pages/pages.js
+++ b/src/mobile/pages/pages.js
@@ -117,6 +117,21 @@ export default Component.extend({
       }
     },
 
+    'button.btn-navigate click': function (el, ev) {
+      const $el = $(el)
+      const isContinueButton = !$el.hasClass('save-answers') &&
+        !$el.hasClass('open-preview') &&
+        !$el.closest('form.post-answers-form, form[action="/api/assemble"]').length
+
+      if (!isContinueButton) { return }
+
+      const vm = this.viewModel
+      if (vm && vm.appState && vm.appState.dispatch) {
+        vm.appState.dispatch('saveOnly')
+      }
+      vm && vm.saveAnswersToServerAsync()
+    },
+
     'button.open-preview click': function (el, ev) {
       ev.preventDefault()
 

--- a/src/modal/modal-test.js
+++ b/src/modal/modal-test.js
@@ -5,6 +5,7 @@ import AppState from '~/src/models/app-state'
 import Interview from '~/src/models/interview'
 import Logic from '~/src/mobile/util/logic'
 import MemoryState from '~/src/models/memory-state'
+import ModalContent from '~/src/models/modal-content'
 import F from 'funcunit'
 import { assert } from 'chai'
 import sinon from 'sinon'
@@ -179,6 +180,35 @@ describe('<a2j-modal> ', function () {
       $('#pageModal').modal('hide')
 
       assert.isTrue(pauseActivePlayersSpy.calledOnce, 'should fire pauseActivePlayers() on modal close to pause audio and video players')
+    })
+
+    it('historyLength returns the number of saved modal history entries', function () {
+      vm.modalHistory.push({ title: 'First' }, { title: 'Second' })
+      assert.equal(vm.historyLength, 2)
+    })
+
+    it('goBack() restores the previous modal content and removes it from history', function () {
+      vm.modalContent = new ModalContent({ title: 'Current', text: 'Current text' })
+      const assignSpy = sinon.spy(vm.modalContent, 'assign')
+      vm.modalHistory.push({ title: 'Previous', text: 'Previous text' })
+
+      vm.goBack()
+
+      assert.isTrue(assignSpy.calledOnce, 'should assign previous content when history exists')
+      assert.equal(vm.modalContent.title, 'Previous')
+      assert.equal(vm.modalContent.text, 'Previous text')
+      assert.equal(vm.historyLength, 0)
+    })
+
+    it('goBack() does nothing when modalHistory is empty', function () {
+      vm.modalContent = new ModalContent({ title: 'Current', text: 'Current text' })
+      const assignSpy = sinon.spy(vm.modalContent, 'assign')
+
+      vm.goBack()
+
+      assert.isFalse(assignSpy.called, 'should not assign anything when history is empty')
+      assert.equal(vm.modalContent.title, 'Current')
+      assert.equal(vm.historyLength, 0)
     })
   })
 })

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -16,6 +16,22 @@ export let ModalVM = DefineMap.extend('ViewerModalVM', {
   interview: {},
   appState: {},
 
+  modalHistory: {
+    default: () => []
+  },
+
+  get historyLength () {
+    return this.modalHistory.length
+  },
+
+  goBack () {
+    if (this.modalHistory.length > 0) {
+      // get latest modal content from history stack and set as current modal content
+      const previousContent = this.modalHistory.pop()
+      this.modalContent.assign(previousContent)
+    }
+  },
+
   // set in appState and cleared here on close
   modalContent: {
     Type: ModalContent
@@ -97,6 +113,8 @@ export let ModalVM = DefineMap.extend('ViewerModalVM', {
       this.triggeringElement.focus()
     }
 
+    // clear history when closing modal to prevent going back to stale content
+    this.modalHistory = []
     // clear for next modal use
     this.modalContent = null
   },
@@ -199,6 +217,19 @@ export default Component.extend({
           if (window._paq) {
             analytics.trackCustomEvent('Pop-Up', 'from: ' + sourcePageName, pageName)
           }
+
+          // push to the history
+          vm.modalHistory.push({
+            title: vm.modalContent.title,
+            text: vm.modalContent.text,
+            textAudioURL: vm.modalContent.textAudioURL,
+            imageURL: vm.modalContent.imageURL,
+            altText: vm.modalContent.altText,
+            mediaLabel: vm.modalContent.mediaLabel,
+            audioURL: vm.modalContent.audioURL,
+            videoURL: vm.modalContent.videoURL,
+            helpReader: vm.modalContent.helpReader
+          })
 
           // popups now have text, audio, video and their alt-text values
           // but title is internal descriptor so set to empty string

--- a/src/modal/modal.less
+++ b/src/modal/modal.less
@@ -120,6 +120,26 @@ a2j-modal {
           }
         }
       }
+      .modal-title {
+        .back {
+          text-shadow: none;
+          color: #fff;
+          background: 0 0;
+          border: 0;
+          padding: 0;
+          opacity: 0.7;
+          &:focus, &:hover, &:active {
+            opacity: 1;
+            outline-color: #fff;
+
+            @supports (-webkit-hyphens:none) { /* safari only */
+              /* Safari doesn't allow you to change the focus outline color, we have to do this instead for a11y. */
+              outline: none;
+              box-shadow: 0 0 2px #fff,  0 0 2px #fff,  0 0 2px #fff,  0 0 2px #fff;
+            }
+          }
+        }
+      }
     }
 
     a.zoom-button {

--- a/src/modal/modal.stache
+++ b/src/modal/modal.stache
@@ -38,6 +38,18 @@
           </button>
 
           <h4 class="modal-title" id="pageModalLbl">
+            {{#if(modalHistory.length > 1)}}
+              <button
+                type="button"
+                class="back"
+                on:click="goBack()"
+                title="Go back to previous content"
+                aria-label="Go back to previous content"
+                tabindex="1"
+              >
+                <span class="glyphicon-left-open" aria-hidden="true"></span>
+              </button>
+            {{/if}}
             {{#if(modalContent.title)}}
               {{ parseText(cleanHTML(modalContent.title)) }}
             {{else}}

--- a/src/modal/modal.stache
+++ b/src/modal/modal.stache
@@ -52,8 +52,6 @@
             {{/if}}
             {{#if(modalContent.title)}}
               {{ parseText(cleanHTML(modalContent.title)) }}
-            {{else}}
-              <span class="glyphicon-lifebuoy" aria-hidden="true"></span>
             {{/if}}
           </h4>
         </div>


### PR DESCRIPTION
## Summary

This PR adds an autosave flow for guided interview progress. As users navigate through the interview, their current answers are now posted to the server in the background so progress is preserved even before the form is fully completed.

### What changed
- Added background answer persistence during navigation
- Coalesced overlapping save requests so only one save runs at a time and the latest answers are sent
- Added unit tests covering the autosave behavior
- Included supporting updates for local development and related UI wiring

### Why
This improves reliability for users who may leave or interrupt an interview before finishing, ensuring their in-progress responses are saved more consistently.